### PR TITLE
prototyping new snap structure

### DIFF
--- a/examples/__snapshots__/parallel_test.snap
+++ b/examples/__snapshots__/parallel_test.snap
@@ -1,40 +1,96 @@
+TestParallel/should_snap_an_integer - 1: |
+    int(10)
+TestParallel/should_snap_an_integer_slice - 1: |
+    []int{1, 2, 3, 4}
 
-[TestParallel/should_snap_an_integer - 1]
-int(10)
----
 
-[TestParallel/should_snap_a_struct_with_fields - 1]
-struct { _ struct {}; name string; id string }{
-    _:    struct {}{},
-    name: "mock-name",
-    id:   "123456",
-}
----
+TestParallel/should_snap_a_buffer - 1: |
+    &bytes.Buffer{
+        buf:      {0x42, 0x75, 0x66, 0x66, 0x65, 0x72, 0x20, 0xTestParallel/should_snap_a_struct - 1: |
+    struct { user string; email string; age int }{user:"gkampitakis", email:"mock@73, 0x74, 0x72, 0x69, 0x6e, 0x67},
+        off:      0,
+        lastRead: 0,
+    }
 
-[TestParallel/should_snap_an_integer_slice - 1]
-[]int{1, 2, 3, 4}
----
+mail.com", age:10}
+TestParallel/should_snap_an_integer - 2: |
+    int(10)
 
-[TestParallel/should_snap_a_float - 1]
-float64(10.5)
----
 
-[TestParallel/should_snap_a_map - 1]
-map[string]int{"value-0":0, "value-1":1, "value-2":2, "value-3":3}
----
+TestParallel/should_snap_a_map - 1: |
+    map[string]int{"value-0":0, "value-1":1, "value-2":2, "value-3":3}
+TestParallel/should_snap_a_pointer - 1: |
+    &int(10)
 
-[TestParallel/should_snap_a_buffer - 1]
-&bytes.Buffer{
-    buf:      {0x42, 0x75, 0x66, 0x66, 0x65, 0x72, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67},
-    off:      0,
-    lastRead: 0,
-}
----
 
-[TestParallel/should_snap_a_pointer - 1]
-&int(10)
----
+TestParallel/should_snap_an_integer - 3: |
+    int(10)
+TestParallel/should_snap_a_struct - 2: |
+    struct { user string; email string; age int }{user:"gkampitakis", email:"mock@
+mail.com", age:10}
 
-[TestParallel/should_snap_a_struct - 1]
-struct { user string; email string; age int }{user:"gkampitakis", email:"mock@mail.com", age:10}
----
+TestParallel/should_snap_a_buffer - 2: |
+    &bytes.Buffer{
+        buf:      {0x42, 0x75, 0x66, 0x66, 0x65, 0x72, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67},
+        off:      0,
+        lastRead: 0,
+    }
+
+TestParallel/should_snap_a_pointer - 2: |
+    &int(10)
+
+TestParallel/should_snap_a_struct - 3: |
+    struct { user string; email string; age int }{user:"gkampitakis", email:"mock@mail.com", age:10}
+
+TestParallel/should_snap_a_pointer - 3: |
+    &int(10)
+TestParallel/should_snap_a_buffer - 3: |
+    &bytes.Buffer{
+        buf:      {0x42, 0x75, 0x66, 0x66, 0x65, 0x72, 0x20, 0xTestParallel/should_snap_a_float - 1: |
+    float64(10.5)
+
+73, 0x74, 0x72, 0x69, 0x6e, 0x67},
+        off:      0,
+        lastRead: 0,
+    }
+
+
+TestParallel/should_snap_a_map - 2: |
+    map[string]int{"value-0":0, "value-1":1, "value-2":2, "value-3":3}
+TestParallel/should_snap_a_float - 2: |
+    float64(10.5)
+TestParallel/should_snap_a_struct_with_fields - 1: |
+    struct { _ struct {}; name string; id string }{
+        _:    stru
+ct {}{},
+        name: "mock-name",
+        id:   "123456",
+    }
+
+
+TestParallel/should_snap_an_integer_slice - 2: |
+    []int{1, 2, 3, 4}
+
+TestParallel/should_snap_a_struct_with_fields - 2: |
+    struct { _ struct {}; name string; id string }{
+        _:    struTestParallel/should_snap_a_float - 3: |
+    float64(10.5)
+
+ct {}{},
+        name: "mock-name",
+        id:   "123456",
+    }
+TestParallel/should_snap_a_map - 3: |
+    map[string]int{"value-0":0, "value-1":1, "value-2":2, "value-3":3}
+
+
+TestParallel/should_snap_an_integer_slice - 3: |
+    []int{1, 2, 3, 4}
+
+TestParallel/should_snap_a_struct_with_fields - 3: |
+    struct { _ struct {}; name string; id string }{
+        _:    struct {}{},
+        name: "mock-name",
+        id:   "123456",
+    }
+

--- a/examples/__snapshots__/simple_test.snap
+++ b/examples/__snapshots__/simple_test.snap
@@ -1,70 +1,63 @@
+TestSimple/should_make_an_int_snapshot - 1: |
+    int(5)
 
-[TestSimple/should_make_an_int_snapshot - 1]
-int(5)
----
+TestSimple/should_make_a_string_snapshot - 1: |
+    string snapshot
 
-[TestSimple/should_make_a_string_snapshot - 1]
-string snapshot
----
+TestSimple/should_make_a_map_snapshot - 1: |
+    map[string]interface {}{
+        "mock-0": "value",
+        "mock-1": int(2),
+        "mock-2": func() {...},
+        "mock-3": float32(10.399999618530273),
+    }
 
-[TestSimple/should_make_a_map_snapshot - 1]
-map[string]interface {}{
-    "mock-0": "value",
-    "mock-1": int(2),
-    "mock-2": func() {...},
-    "mock-3": float32(10.399999618530273),
-}
----
+TestSimple/should_make_multiple_entries_in_snapshot - 1: |
+    int(5)
 
-[TestSimple/should_make_multiple_entries_in_snapshot - 1]
-int(5)
-int(10)
-int(20)
-int(25)
----
+TestSimple/should_make_multiple_entries_in_snapshot - 2: |
+    int(10)
 
-[TestSimple/should_make_create_multiple_snapshot - 1]
-int(1000)
----
+TestSimple/should_make_multiple_entries_in_snapshot - 3: |
+    int(20)
 
-[TestSimple/should_make_create_multiple_snapshot - 2]
-another snapshot
----
+TestSimple/should_make_multiple_entries_in_snapshot - 4: |
+    int(25)
 
-[TestSimple/should_make_create_multiple_snapshot - 3]
-{
-            "user": "gkampitakis",
-            "id": 1234567,
-            "data": [ ]
-        }
----
+TestSimple/should_make_create_multiple_snapshot - 1: |
+    int(1000)
 
-[TestSimpleTable/string - 1]
-input
----
+TestSimple/should_make_create_multiple_snapshot - 2: |
+    another snapshot
 
-[TestSimpleTable/integer - 1]
-int(10)
----
+TestSimple/should_make_create_multiple_snapshot - 3: |
+    {
+                "user": "gkampitakis",
+                "id": 1234567,
+                "data": [ ]
+            }
 
-[TestSimpleTable/map - 1]
-map[string]interface {}{
-    "test": func() {...},
-}
----
+TestSimple/nest/more/one_more_nested_test - 1: |
+    it's okay
 
-[TestSimple/nest/more/one_more_nested_test - 1]
-it's okay
----
+TestSimple/.* - 1: |
+    ignore regex patterns on names
 
-[TestSimpleTable/buffer - 1]
-&bytes.Buffer{
-    buf:      {0x42, 0x75, 0x66, 0x66, 0x65, 0x72, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67},
-    off:      0,
-    lastRead: 0,
-}
----
+TestSimpleTable/string - 1: |
+    input
 
-[TestSimple/.* - 1]
-ignore regex patterns on names
----
+TestSimpleTable/integer - 1: |
+    int(10)
+
+TestSimpleTable/map - 1: |
+    map[string]interface {}{
+        "test": func() {...},
+    }
+
+TestSimpleTable/buffer - 1: |
+    &bytes.Buffer{
+        buf:      {0x42, 0x75, 0x66, 0x66, 0x65, 0x72, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67},
+        off:      0,
+        lastRead: 0,
+    }
+

--- a/examples/parallel_test.go
+++ b/examples/parallel_test.go
@@ -78,6 +78,8 @@ func TestParallel(t *testing.T) {
 			t.Parallel()
 
 			snaps.MatchSnapshot(t, s.input)
+			snaps.MatchSnapshot(t, s.input)
+			snaps.MatchSnapshot(t, s.input)
 		})
 	}
 }

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -37,7 +37,10 @@ func TestSimple(t *testing.T) {
 	})
 
 	t.Run("should make multiple entries in snapshot", func(t *testing.T) {
-		snaps.MatchSnapshot(t, 5, 10, 20, 25)
+		snaps.MatchSnapshot(t, 5)
+		snaps.MatchSnapshot(t, 10)
+		snaps.MatchSnapshot(t, 20)
+		snaps.MatchSnapshot(t, 25)
 	})
 
 	t.Run("should make create multiple snapshot", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,7 @@ require (
 	github.com/sergi/go-diff v1.2.0
 )
 
-require github.com/rogpeppe/go-internal v1.8.1 // indirect
+require (
+	github.com/rogpeppe/go-internal v1.8.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -25,9 +25,11 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/snaps/regexp_test.go
+++ b/snaps/regexp_test.go
@@ -1,0 +1,17 @@
+package snaps
+
+import "testing"
+
+func TestRegexp(t *testing.T) {
+	t.Parallel()
+
+	t.Run("testIDRegexp", func(t *testing.T) {})
+
+	t.Run("spacesRegexp", func(t *testing.T) {})
+
+	t.Run("endCharRegexp", func(t *testing.T) {})
+
+	t.Run("endCharEscapedRegexp", func(t *testing.T) {})
+
+	t.Run("dynamicTestIDRegexp", func(t *testing.T) {})
+}

--- a/snaps/snaps_test.go
+++ b/snaps/snaps_test.go
@@ -1,35 +1,44 @@
 package snaps
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/gkampitakis/ciinfo"
 )
 
-const mockSnap = `
+// import (
+// 	"errors"
+// 	"fmt"
+// 	"os"
+// 	"path/filepath"
+// 	"reflect"
+// 	"strings"
+// 	"testing"
 
-[Test_1/TestSimple - 1]
-int(1)
-string hello world 1 1 1
----
+// 	"github.com/gkampitakis/ciinfo"
+// )
 
-[Test_3/TestSimple - 1]
-int(100)
-string hello world 1 3 1
----
+// const mockSnap = `
 
-[Test_3/TestSimple - 2]
-int(1000)
-string hello world 1 3 2
----
+// [Test_1/TestSimple - 1]
+// int(1)
+// string hello world 1 1 1
+// ---
 
-`
+// [Test_3/TestSimple - 1]
+// int(100)
+// string hello world 1 3 1
+// ---
+
+// [Test_3/TestSimple - 2]
+// int(1000)
+// string hello world 1 3 2
+// ---
+
+// `
 
 // Testing Helper Functions - Start
 
@@ -66,392 +75,392 @@ func createTempFile(t *testing.T, data string) string {
 
 // Testing Helper Functions - End
 
-func TestInternalMethods(t *testing.T) {
-	t.Run("getPrevSnapshot", func(t *testing.T) {
-		t.Run("should return errSnapNotFound", func(t *testing.T) {
-			snap, err := getPrevSnapshot("", "")
-
-			Equal(t, "", snap)
-			Equal(t, err, errSnapNotFound)
-		})
-
-		t.Run("should return errSnapNotFound if no match found", func(t *testing.T) {
-			fileData := "test"
-			path := createTempFile(t, fileData)
-			snap, err := getPrevSnapshot("", path)
-
-			Equal(t, "", snap)
-			Equal(t, errSnapNotFound, err)
-		})
-
-		for _, scenario := range []struct {
-			description string
-			testID      string
-			fileData    string
-			snap        string
-			err         error
-		}{
-			{
-				description: "should not match if no data",
-				testID:      "my-test",
-				fileData:    ``,
-				snap:        ``,
-				err:         errSnapNotFound,
-			},
-			{
-				description: "should not match",
-				testID:      "my-test",
-				fileData:    `mysnapshot`,
-				snap:        ``,
-				err:         errSnapNotFound,
-			},
-			{
-				description: "should return match",
-				testID:      "[my-test - 1]",
-				fileData:    "[my-test - 1]\nmysnapshot\n---\n",
-				snap:        "mysnapshot\n",
-				err:         nil,
-			},
-			{
-				description: "should ignore regex in testID and match correct snap",
-				testID:      "[.*]",
-				fileData:    "\n[my-test]\nwrong snap\n---\n\n[.*]\nmysnapshot\n---\n",
-				snap:        "mysnapshot\n",
-				err:         nil,
-			},
-			{
-				description: "should ignore end chars (---) inside snapshot",
-				testID:      "[mock-test 1]",
-				fileData:    "\n[mock-test 1]\nmysnapshot\n---moredata\n---\n",
-				snap:        "mysnapshot\n---moredata\n",
-				err:         nil,
-			},
-		} {
-			s := scenario
-			t.Run(s.description, func(t *testing.T) {
-				t.Parallel()
-
-				path := createTempFile(t, s.fileData)
-				snap, err := getPrevSnapshot(s.testID, path)
-
-				Equal(t, s.err, err)
-				Equal(t, s.snap, snap)
-			})
-		}
-	})
-
-	t.Run("addNewSnapshot", func(t *testing.T) {
-		dir := filepath.Join(t.TempDir(), "__snapshots__")
-		name := filepath.Join(dir, "mock-test.snap")
-		err := addNewSnapshot("[mock-id]", "my-snap\n", dir, name)
-
-		Equal(t, nil, err)
-
-		snap, err := snapshotFileToString(name)
-
-		Equal(t, nil, err)
-		Equal(t, "\n[mock-id]\nmy-snap\n---\n", snap)
-	})
-
-	t.Run("snapPathAndFile", func(t *testing.T) {
-		path, file := snapDirAndName()
-
-		Contains(t, path, filepath.FromSlash("/snaps/__snapshots__"))
-		Contains(t, file, filepath.FromSlash("/snaps/__snapshots__/snaps_test.snap"))
-	})
-
-	t.Run("updateSnapshot", func(t *testing.T) {
-		const updatedSnap = `
-
-[Test_1/TestSimple - 1]
-int(1)
-string hello world 1 1 1
----
-
-[Test_3/TestSimple - 1]
-int(1250)
-string new value
----
-
-[Test_3/TestSimple - 2]
-int(1000)
-string hello world 1 3 2
----
-
-`
-		snapPath := createTempFile(t, mockSnap)
-		newSnapshot := "int(1250)\nstring new value\n"
-		err := updateSnapshot("[Test_3/TestSimple - 1]", newSnapshot, snapPath)
-		snap, _ := os.ReadFile(snapPath)
-
-		Equal(t, nil, err)
-		Equal(t, updatedSnap, string(snap))
-	})
-}
-
-func TestMatchSnapshot(t *testing.T) {
-	t.Run("should create snapshot", func(t *testing.T) {
-		dir, _ := os.Getwd()
-		snapPath := filepath.Join(dir, "__snapshots__", "snaps_test.snap")
-		isCI = false
-
-		t.Cleanup(func() {
-			os.RemoveAll(filepath.Join(dir, "__snapshots__"))
-			testsRegistry = newRegistry()
-			isCI = ciinfo.IsCI
-		})
-
-		_, err := os.Stat(snapPath)
-
-		Equal(t, true, errors.Is(err, os.ErrNotExist))
-
-		mockT := MockTestingT{
-			mockHelper: func() {},
-			mockName: func() string {
-				return "mock-name"
-			},
-			mockError: func(args ...interface{}) {
-				NotCalled(t)
-			},
-			mockLog: func(args ...interface{}) {
-				Equal(t, greenText(arrowPoint+"New snapshot written.\n"), args[0])
-			},
-		}
-
-		matchSnapshot(mockT, []interface{}{10, "hello world"})
-
-		snap, err := snapshotFileToString(snapPath)
-		Equal(t, nil, err)
-		Equal(t, "\n[mock-name - 1]\nint(10)\nhello world\n---\n", snap)
-	})
-
-	t.Run("if it's running on ci should skip", func(t *testing.T) {
-		dir, _ := os.Getwd()
-		snapPath := filepath.Join(dir, "__snapshots__", "snaps_test.snap")
-		isCI = true
-
-		t.Cleanup(func() {
-			os.RemoveAll(filepath.Join(dir, "__snapshots__"))
-			testsRegistry = newRegistry()
-			isCI = ciinfo.IsCI
-		})
-
-		_, err := os.Stat(snapPath)
-
-		Equal(t, true, errors.Is(err, os.ErrNotExist))
-
-		mockT := MockTestingT{
-			mockHelper: func() {},
-			mockName: func() string {
-				return "mock-name"
-			},
-			mockError: func(args ...interface{}) {
-				Equal(t, errSnapNotFound, args[0])
-			},
-			mockLog: func(args ...interface{}) {
-				NotCalled(t)
-			},
-		}
-
-		matchSnapshot(mockT, []interface{}{10, "hello world"})
-
-		_, err = snapshotFileToString(snapPath)
-		Equal(t, errSnapNotFound, err)
-	})
-
-	t.Run("should return error when diff is found", func(t *testing.T) {
-		dir, _ := os.Getwd()
-		snapPath := filepath.Join(dir, "__snapshots__", "snaps_test.snap")
-		printerExpectedCalls := []func(received interface{}){
-			func(received interface{}) {
-				Equal(t, greenText(arrowPoint+"New snapshot written.\n"), received)
-			},
-			func(received interface{}) { NotCalled(t) },
-		}
-		isCI = false
-
-		t.Cleanup(func() {
-			os.RemoveAll(filepath.Join(dir, "__snapshots__"))
-			testsRegistry = newRegistry()
-			isCI = ciinfo.IsCI
-		})
-
-		_, err := os.Stat(snapPath)
-		// This is for checking we are starting with a clean state testing
-		Equal(t, true, errors.Is(err, os.ErrNotExist))
-
-		mockT := MockTestingT{
-			mockHelper: func() {},
-			mockName: func() string {
-				return "mock-name"
-			},
-			mockError: func(args ...interface{}) {
-				expected := "\n\x1b[41m\x1b[37;1m Snapshot \x1b[0m\n\x1b[42m\x1b[37;1m" +
-					" Received \x1b[0m\n\n\x1b[2mint(10\x1b[0m\x1b[32;1m0\x1b[0m\x1b[2m)\n\x1b" +
-					"[0m\x1b[31;1mhello\x1b[0m\x1b[32;1mbye\x1b[0m\x1b[2m world\n\x1b[0m\n"
-
-				Equal(t, expected, args[0])
-			},
-			mockLog: func(args ...interface{}) {
-				printerExpectedCalls[0](args[0])
-
-				// shift
-				printerExpectedCalls = printerExpectedCalls[1:]
-			},
-		}
-
-		// First call for creating the snapshot
-		matchSnapshot(mockT, []interface{}{10, "hello world"})
-
-		// Resetting registry to emulate the same matchSnapshot call
-		testsRegistry = newRegistry()
-
-		// Second call with different params
-		matchSnapshot(mockT, []interface{}{100, "bye world"})
-	})
-
-	t.Run("should update snapshot when 'shouldUpdate'", func(t *testing.T) {
-		dir, _ := os.Getwd()
-		snapPath := filepath.Join(dir, "__snapshots__", "snaps_test.snap")
-		isCI = false
-		shouldUpdatePrev := shouldUpdate
-		shouldUpdate = true
-		printerExpectedCalls := []func(received interface{}){
-			func(received interface{}) {
-				Equal(t, greenText(arrowPoint+"New snapshot written.\n"), received)
-			},
-			func(received interface{}) {
-				Equal(t, greenText(arrowPoint+"Snapshot updated.\n"), received)
-			},
-		}
-
-		t.Cleanup(func() {
-			os.RemoveAll(filepath.Join(dir, "__snapshots__"))
-			testsRegistry = newRegistry()
-			isCI = ciinfo.IsCI
-			shouldUpdate = shouldUpdatePrev
-		})
-
-		_, err := os.Stat(snapPath)
-		// This is for checking we are starting with a clean state testing
-		Equal(t, true, errors.Is(err, os.ErrNotExist))
-
-		mockT := MockTestingT{
-			mockHelper: func() {},
-			mockName: func() string {
-				return "mock-name"
-			},
-			mockError: func(args ...interface{}) {
-				NotCalled(t)
-			},
-			mockLog: func(args ...interface{}) {
-				printerExpectedCalls[0](args[0])
-
-				// shift
-				printerExpectedCalls = printerExpectedCalls[1:]
-			},
-		}
-
-		// First call for creating the snapshot
-		matchSnapshot(mockT, []interface{}{10, "hello world"})
-
-		// Resetting registry to emulate the same matchSnapshot call
-		testsRegistry = newRegistry()
-
-		// Second call with different params
-		matchSnapshot(mockT, []interface{}{100, "bye world"})
-
-		snap, err := snapshotFileToString(snapPath)
-		Equal(t, nil, err)
-		Equal(t, "\n[mock-name - 1]\nint(100)\nbye world\n---\n", snap)
-	})
-
-	t.Run("should print warning if no params provided", func(t *testing.T) {
-		mockT := MockTestingT{
-			mockHelper: func() {},
-			mockLog: func(args ...interface{}) {
-				Equal(t, yellowText("[warning] MatchSnapshot call without params\n"), args[0])
-			},
-		}
-
-		matchSnapshot(mockT, []interface{}{})
-		matchSnapshot(mockT, nil)
-	})
-
-	t.Run("diff should not print the escaped characters", func(t *testing.T) {
-		dir, _ := os.Getwd()
-		snapPath := filepath.Join(dir, "__snapshots__", "snaps_test.snap")
-		printerExpectedCalls := []func(received interface{}){
-			func(received interface{}) {
-				Equal(t, greenText(arrowPoint+"New snapshot written.\n"), received)
-			},
-			func(received interface{}) { NotCalled(t) },
-		}
-		isCI = false
-
-		t.Cleanup(func() {
-			os.RemoveAll(filepath.Join(dir, "__snapshots__"))
-			testsRegistry = newRegistry()
-			isCI = ciinfo.IsCI
-		})
-
-		_, err := os.Stat(snapPath)
-		// This is for checking we are starting with a clean state testing
-		Equal(t, true, errors.Is(err, os.ErrNotExist))
-
-		mockT := MockTestingT{
-			mockHelper: func() {},
-			mockName: func() string {
-				return "mock-name"
-			},
-			mockError: func(args ...interface{}) {
-				expected := "\n\x1b[41m\x1b[37;1m Snapshot \x1b[0m\n\x1b[42m\x1b[37;1m Received " +
-					"\x1b[0m\n\n\x1b[2mint(10\x1b[0m\x1b[32;1m0\x1b[0m\x1b[2m)\n\x1b[0m\x1b[31;1m" +
-					"hello\x1b[0m\x1b[32;1mbye\x1b[0m\x1b[2m world----\n--\x1b[0m\x1b[31;1m-\x1b[0m\x1b[2m\n\x1b[0m\n"
-
-				Equal(t, expected, args[0])
-			},
-			mockLog: func(args ...interface{}) {
-				printerExpectedCalls[0](args[0])
-
-				// shift
-				printerExpectedCalls = printerExpectedCalls[1:]
-			},
-		}
-
-		// First call for creating the snapshot ( adding ending chars inside the diff )
-		matchSnapshot(mockT, []interface{}{10, "hello world----", "---"})
-
-		// Resetting registry to emulate the same matchSnapshot call
-		testsRegistry = newRegistry()
-
-		// Second call with different params
-		matchSnapshot(mockT, []interface{}{100, "bye world----", "--"})
-	})
-}
-
-func TestEscapeEndChars(t *testing.T) {
-	t.Run("should escape end chars inside data", func(t *testing.T) {
-		dir := filepath.Join(t.TempDir(), "__snapshots__")
-		name := filepath.Join(dir, "mock-test.snap")
-		snapshot := takeSnapshot([]interface{}{"my-snap", "---"})
-		err := addNewSnapshot("[mock-id]", snapshot, dir, name)
-
-		Equal(t, nil, err)
-		snap, err := snapshotFileToString(name)
-		Equal(t, nil, err)
-		Equal(t, "\n[mock-id]\nmy-snap\n/-/-/-/\n---\n", snap)
-	})
-
-	t.Run("should not escape --- if not end chars", func(t *testing.T) {
-		dir := filepath.Join(t.TempDir(), "__snapshots__")
-		name := filepath.Join(dir, "mock-test.snap")
-		snapshot := takeSnapshot([]interface{}{"my-snap---", "---"})
-		err := addNewSnapshot("[mock-id]", snapshot, dir, name)
-
-		Equal(t, nil, err)
-		snap, err := snapshotFileToString(name)
-		Equal(t, nil, err)
-		Equal(t, "\n[mock-id]\nmy-snap---\n/-/-/-/\n---\n", snap)
-	})
-}
+// func TestInternalMethods(t *testing.T) {
+// 	t.Run("getPrevSnapshot", func(t *testing.T) {
+// 		t.Run("should return errSnapNotFound", func(t *testing.T) {
+// 			snap, err := getPrevSnapshot("", "")
+
+// 			Equal(t, "", snap)
+// 			Equal(t, err, errSnapNotFound)
+// 		})
+
+// 		t.Run("should return errSnapNotFound if no match found", func(t *testing.T) {
+// 			fileData := "test"
+// 			path := createTempFile(t, fileData)
+// 			snap, err := getPrevSnapshot("", path)
+
+// 			Equal(t, "", snap)
+// 			Equal(t, errSnapNotFound, err)
+// 		})
+
+// 		for _, scenario := range []struct {
+// 			description string
+// 			testID      string
+// 			fileData    string
+// 			snap        string
+// 			err         error
+// 		}{
+// 			{
+// 				description: "should not match if no data",
+// 				testID:      "my-test",
+// 				fileData:    ``,
+// 				snap:        ``,
+// 				err:         errSnapNotFound,
+// 			},
+// 			{
+// 				description: "should not match",
+// 				testID:      "my-test",
+// 				fileData:    `mysnapshot`,
+// 				snap:        ``,
+// 				err:         errSnapNotFound,
+// 			},
+// 			{
+// 				description: "should return match",
+// 				testID:      "[my-test - 1]",
+// 				fileData:    "[my-test - 1]\nmysnapshot\n---\n",
+// 				snap:        "mysnapshot\n",
+// 				err:         nil,
+// 			},
+// 			{
+// 				description: "should ignore regex in testID and match correct snap",
+// 				testID:      "[.*]",
+// 				fileData:    "\n[my-test]\nwrong snap\n---\n\n[.*]\nmysnapshot\n---\n",
+// 				snap:        "mysnapshot\n",
+// 				err:         nil,
+// 			},
+// 			{
+// 				description: "should ignore end chars (---) inside snapshot",
+// 				testID:      "[mock-test 1]",
+// 				fileData:    "\n[mock-test 1]\nmysnapshot\n---moredata\n---\n",
+// 				snap:        "mysnapshot\n---moredata\n",
+// 				err:         nil,
+// 			},
+// 		} {
+// 			s := scenario
+// 			t.Run(s.description, func(t *testing.T) {
+// 				t.Parallel()
+
+// 				path := createTempFile(t, s.fileData)
+// 				snap, err := getPrevSnapshot(s.testID, path)
+
+// 				Equal(t, s.err, err)
+// 				Equal(t, s.snap, snap)
+// 			})
+// 		}
+// 	})
+
+// 	t.Run("addNewSnapshot", func(t *testing.T) {
+// 		dir := filepath.Join(t.TempDir(), "__snapshots__")
+// 		name := filepath.Join(dir, "mock-test.snap")
+// 		err := addNewSnapshot("[mock-id]", "my-snap\n", dir, name)
+
+// 		Equal(t, nil, err)
+
+// 		snap, err := snapshotFileToString(name)
+
+// 		Equal(t, nil, err)
+// 		Equal(t, "\n[mock-id]\nmy-snap\n---\n", snap)
+// 	})
+
+// 	t.Run("snapPathAndFile", func(t *testing.T) {
+// 		path, file := snapDirAndName()
+
+// 		Contains(t, path, filepath.FromSlash("/snaps/__snapshots__"))
+// 		Contains(t, file, filepath.FromSlash("/snaps/__snapshots__/snaps_test.snap"))
+// 	})
+
+// 	t.Run("updateSnapshot", func(t *testing.T) {
+// 		const updatedSnap = `
+
+// [Test_1/TestSimple - 1]
+// int(1)
+// string hello world 1 1 1
+// ---
+
+// [Test_3/TestSimple - 1]
+// int(1250)
+// string new value
+// ---
+
+// [Test_3/TestSimple - 2]
+// int(1000)
+// string hello world 1 3 2
+// ---
+
+// `
+// 		snapPath := createTempFile(t, mockSnap)
+// 		newSnapshot := "int(1250)\nstring new value\n"
+// 		err := updateSnapshot("[Test_3/TestSimple - 1]", newSnapshot, snapPath)
+// 		snap, _ := os.ReadFile(snapPath)
+
+// 		Equal(t, nil, err)
+// 		Equal(t, updatedSnap, string(snap))
+// 	})
+// }
+
+// func TestMatchSnapshot(t *testing.T) {
+// 	t.Run("should create snapshot", func(t *testing.T) {
+// 		dir, _ := os.Getwd()
+// 		snapPath := filepath.Join(dir, "__snapshots__", "snaps_test.snap")
+// 		isCI = false
+
+// 		t.Cleanup(func() {
+// 			os.RemoveAll(filepath.Join(dir, "__snapshots__"))
+// 			testsRegistry = newRegistry()
+// 			isCI = ciinfo.IsCI
+// 		})
+
+// 		_, err := os.Stat(snapPath)
+
+// 		Equal(t, true, errors.Is(err, os.ErrNotExist))
+
+// 		mockT := MockTestingT{
+// 			mockHelper: func() {},
+// 			mockName: func() string {
+// 				return "mock-name"
+// 			},
+// 			mockError: func(args ...interface{}) {
+// 				NotCalled(t)
+// 			},
+// 			mockLog: func(args ...interface{}) {
+// 				Equal(t, greenText(arrowPoint+"New snapshot written.\n"), args[0])
+// 			},
+// 		}
+
+// 		matchSnapshot(mockT, []interface{}{10, "hello world"})
+
+// 		snap, err := snapshotFileToString(snapPath)
+// 		Equal(t, nil, err)
+// 		Equal(t, "\n[mock-name - 1]\nint(10)\nhello world\n---\n", snap)
+// 	})
+
+// 	t.Run("if it's running on ci should skip", func(t *testing.T) {
+// 		dir, _ := os.Getwd()
+// 		snapPath := filepath.Join(dir, "__snapshots__", "snaps_test.snap")
+// 		isCI = true
+
+// 		t.Cleanup(func() {
+// 			os.RemoveAll(filepath.Join(dir, "__snapshots__"))
+// 			testsRegistry = newRegistry()
+// 			isCI = ciinfo.IsCI
+// 		})
+
+// 		_, err := os.Stat(snapPath)
+
+// 		Equal(t, true, errors.Is(err, os.ErrNotExist))
+
+// 		mockT := MockTestingT{
+// 			mockHelper: func() {},
+// 			mockName: func() string {
+// 				return "mock-name"
+// 			},
+// 			mockError: func(args ...interface{}) {
+// 				Equal(t, errSnapNotFound, args[0])
+// 			},
+// 			mockLog: func(args ...interface{}) {
+// 				NotCalled(t)
+// 			},
+// 		}
+
+// 		matchSnapshot(mockT, []interface{}{10, "hello world"})
+
+// 		_, err = snapshotFileToString(snapPath)
+// 		Equal(t, errSnapNotFound, err)
+// 	})
+
+// 	t.Run("should return error when diff is found", func(t *testing.T) {
+// 		dir, _ := os.Getwd()
+// 		snapPath := filepath.Join(dir, "__snapshots__", "snaps_test.snap")
+// 		printerExpectedCalls := []func(received interface{}){
+// 			func(received interface{}) {
+// 				Equal(t, greenText(arrowPoint+"New snapshot written.\n"), received)
+// 			},
+// 			func(received interface{}) { NotCalled(t) },
+// 		}
+// 		isCI = false
+
+// 		t.Cleanup(func() {
+// 			os.RemoveAll(filepath.Join(dir, "__snapshots__"))
+// 			testsRegistry = newRegistry()
+// 			isCI = ciinfo.IsCI
+// 		})
+
+// 		_, err := os.Stat(snapPath)
+// 		// This is for checking we are starting with a clean state testing
+// 		Equal(t, true, errors.Is(err, os.ErrNotExist))
+
+// 		mockT := MockTestingT{
+// 			mockHelper: func() {},
+// 			mockName: func() string {
+// 				return "mock-name"
+// 			},
+// 			mockError: func(args ...interface{}) {
+// 				expected := "\n\x1b[41m\x1b[37;1m Snapshot \x1b[0m\n\x1b[42m\x1b[37;1m" +
+// 					" Received \x1b[0m\n\n\x1b[2mint(10\x1b[0m\x1b[32;1m0\x1b[0m\x1b[2m)\n\x1b" +
+// 					"[0m\x1b[31;1mhello\x1b[0m\x1b[32;1mbye\x1b[0m\x1b[2m world\n\x1b[0m\n"
+
+// 				Equal(t, expected, args[0])
+// 			},
+// 			mockLog: func(args ...interface{}) {
+// 				printerExpectedCalls[0](args[0])
+
+// 				// shift
+// 				printerExpectedCalls = printerExpectedCalls[1:]
+// 			},
+// 		}
+
+// 		// First call for creating the snapshot
+// 		matchSnapshot(mockT, []interface{}{10, "hello world"})
+
+// 		// Resetting registry to emulate the same matchSnapshot call
+// 		testsRegistry = newRegistry()
+
+// 		// Second call with different params
+// 		matchSnapshot(mockT, []interface{}{100, "bye world"})
+// 	})
+
+// 	t.Run("should update snapshot when 'shouldUpdate'", func(t *testing.T) {
+// 		dir, _ := os.Getwd()
+// 		snapPath := filepath.Join(dir, "__snapshots__", "snaps_test.snap")
+// 		isCI = false
+// 		shouldUpdatePrev := shouldUpdate
+// 		shouldUpdate = true
+// 		printerExpectedCalls := []func(received interface{}){
+// 			func(received interface{}) {
+// 				Equal(t, greenText(arrowPoint+"New snapshot written.\n"), received)
+// 			},
+// 			func(received interface{}) {
+// 				Equal(t, greenText(arrowPoint+"Snapshot updated.\n"), received)
+// 			},
+// 		}
+
+// 		t.Cleanup(func() {
+// 			os.RemoveAll(filepath.Join(dir, "__snapshots__"))
+// 			testsRegistry = newRegistry()
+// 			isCI = ciinfo.IsCI
+// 			shouldUpdate = shouldUpdatePrev
+// 		})
+
+// 		_, err := os.Stat(snapPath)
+// 		// This is for checking we are starting with a clean state testing
+// 		Equal(t, true, errors.Is(err, os.ErrNotExist))
+
+// 		mockT := MockTestingT{
+// 			mockHelper: func() {},
+// 			mockName: func() string {
+// 				return "mock-name"
+// 			},
+// 			mockError: func(args ...interface{}) {
+// 				NotCalled(t)
+// 			},
+// 			mockLog: func(args ...interface{}) {
+// 				printerExpectedCalls[0](args[0])
+
+// 				// shift
+// 				printerExpectedCalls = printerExpectedCalls[1:]
+// 			},
+// 		}
+
+// 		// First call for creating the snapshot
+// 		matchSnapshot(mockT, []interface{}{10, "hello world"})
+
+// 		// Resetting registry to emulate the same matchSnapshot call
+// 		testsRegistry = newRegistry()
+
+// 		// Second call with different params
+// 		matchSnapshot(mockT, []interface{}{100, "bye world"})
+
+// 		snap, err := snapshotFileToString(snapPath)
+// 		Equal(t, nil, err)
+// 		Equal(t, "\n[mock-name - 1]\nint(100)\nbye world\n---\n", snap)
+// 	})
+
+// 	t.Run("should print warning if no params provided", func(t *testing.T) {
+// 		mockT := MockTestingT{
+// 			mockHelper: func() {},
+// 			mockLog: func(args ...interface{}) {
+// 				Equal(t, yellowText("[warning] MatchSnapshot call without params\n"), args[0])
+// 			},
+// 		}
+
+// 		matchSnapshot(mockT, []interface{}{})
+// 		matchSnapshot(mockT, nil)
+// 	})
+
+// 	t.Run("diff should not print the escaped characters", func(t *testing.T) {
+// 		dir, _ := os.Getwd()
+// 		snapPath := filepath.Join(dir, "__snapshots__", "snaps_test.snap")
+// 		printerExpectedCalls := []func(received interface{}){
+// 			func(received interface{}) {
+// 				Equal(t, greenText(arrowPoint+"New snapshot written.\n"), received)
+// 			},
+// 			func(received interface{}) { NotCalled(t) },
+// 		}
+// 		isCI = false
+
+// 		t.Cleanup(func() {
+// 			os.RemoveAll(filepath.Join(dir, "__snapshots__"))
+// 			testsRegistry = newRegistry()
+// 			isCI = ciinfo.IsCI
+// 		})
+
+// 		_, err := os.Stat(snapPath)
+// 		// This is for checking we are starting with a clean state testing
+// 		Equal(t, true, errors.Is(err, os.ErrNotExist))
+
+// 		mockT := MockTestingT{
+// 			mockHelper: func() {},
+// 			mockName: func() string {
+// 				return "mock-name"
+// 			},
+// 			mockError: func(args ...interface{}) {
+// 				expected := "\n\x1b[41m\x1b[37;1m Snapshot \x1b[0m\n\x1b[42m\x1b[37;1m Received " +
+// 					"\x1b[0m\n\n\x1b[2mint(10\x1b[0m\x1b[32;1m0\x1b[0m\x1b[2m)\n\x1b[0m\x1b[31;1m" +
+// 					"hello\x1b[0m\x1b[32;1mbye\x1b[0m\x1b[2m world----\n--\x1b[0m\x1b[31;1m-\x1b[0m\x1b[2m\n\x1b[0m\n"
+
+// 				Equal(t, expected, args[0])
+// 			},
+// 			mockLog: func(args ...interface{}) {
+// 				printerExpectedCalls[0](args[0])
+
+// 				// shift
+// 				printerExpectedCalls = printerExpectedCalls[1:]
+// 			},
+// 		}
+
+// 		// First call for creating the snapshot ( adding ending chars inside the diff )
+// 		matchSnapshot(mockT, []interface{}{10, "hello world----", "---"})
+
+// 		// Resetting registry to emulate the same matchSnapshot call
+// 		testsRegistry = newRegistry()
+
+// 		// Second call with different params
+// 		matchSnapshot(mockT, []interface{}{100, "bye world----", "--"})
+// 	})
+// }
+
+// func TestEscapeEndChars(t *testing.T) {
+// 	t.Run("should escape end chars inside data", func(t *testing.T) {
+// 		dir := filepath.Join(t.TempDir(), "__snapshots__")
+// 		name := filepath.Join(dir, "mock-test.snap")
+// 		snapshot := takeSnapshot([]interface{}{"my-snap", "---"})
+// 		err := addNewSnapshot("[mock-id]", snapshot, dir, name)
+
+// 		Equal(t, nil, err)
+// 		snap, err := snapshotFileToString(name)
+// 		Equal(t, nil, err)
+// 		Equal(t, "\n[mock-id]\nmy-snap\n/-/-/-/\n---\n", snap)
+// 	})
+
+// 	t.Run("should not escape --- if not end chars", func(t *testing.T) {
+// 		dir := filepath.Join(t.TempDir(), "__snapshots__")
+// 		name := filepath.Join(dir, "mock-test.snap")
+// 		snapshot := takeSnapshot([]interface{}{"my-snap---", "---"})
+// 		err := addNewSnapshot("[mock-id]", snapshot, dir, name)
+
+// 		Equal(t, nil, err)
+// 		snap, err := snapshotFileToString(name)
+// 		Equal(t, nil, err)
+// 		Equal(t, "\n[mock-id]\nmy-snap---\n/-/-/-/\n---\n", snap)
+// 	})
+// }


### PR DESCRIPTION
Move away from the current snapshot structure. That would help get rid of the error-prone regex matching logic in all the project

- [ ] Use yaml map[string]string structure
- [ ] Drop variadic parameters in MatchSnapshot function  ( can call the function multiple times for the same functionality ). Also doesn't allow space for "potentially" evolving the function in the future 