### PR TITLE
fix: update isSkippedFile, replace file absolute match w/ regex match

### DIFF
--- a/snaps/skip.go
+++ b/snaps/skip.go
@@ -67,11 +67,6 @@ e.g
 Then every "child" test should be skipped
 */
 func testSkipped(testID, runOnly string) bool {
-	matched, _ := regexp.Match(runOnly, []byte(testID))
-
-	if runOnly != "" && !matched {
-		return true
-	}
 
 	// testID form: Test.*/runName - 1
 	testName := strings.Split(testID, " - ")[0]
@@ -81,8 +76,9 @@ func testSkipped(testID, runOnly string) bool {
 			return true
 		}
 	}
-
-	return false
+	
+	matched, _ := regexp.MatchString(runOnly, testID)
+	return !matched
 }
 
 func isFileSkipped(dir, filename, runOnly string) bool {
@@ -108,7 +104,8 @@ func isFileSkipped(dir, filename, runOnly string) bool {
 		}
 
 		// If the TestFunction is inside the file then it's not skipped
-		if funcDecl.Name.String() == runOnly {
+		matched, _ := regexp.MatchString(runOnly, funcDecl.Name.String())
+		if matched {
 			isSkipped = false
 		}
 	}

--- a/snaps/skip.go
+++ b/snaps/skip.go
@@ -67,7 +67,6 @@ e.g
 Then every "child" test should be skipped
 */
 func testSkipped(testID, runOnly string) bool {
-
 	// testID form: Test.*/runName - 1
 	testName := strings.Split(testID, " - ")[0]
 
@@ -76,7 +75,7 @@ func testSkipped(testID, runOnly string) bool {
 			return true
 		}
 	}
-	
+
 	matched, _ := regexp.MatchString(runOnly, testID)
 	return !matched
 }

--- a/snaps/skip_test.go
+++ b/snaps/skip_test.go
@@ -210,7 +210,11 @@ func TestSkip(t *testing.T) {
 		t.Run("should use regex match for runOnly", func(t *testing.T) {
 			dir, _ := os.Getwd()
 
-			test.Equal(t, false, isFileSkipped(dir+"/__snapshots__", "skip_test.snap", "	TestSkip.*"))
+			test.Equal(
+				t,
+				false,
+				isFileSkipped(dir+"/__snapshots__", "skip_test.snap", "TestSkip.*"),
+			)
 		})
 	})
 }

--- a/snaps/skip_test.go
+++ b/snaps/skip_test.go
@@ -206,5 +206,11 @@ func TestSkip(t *testing.T) {
 
 			test.Equal(t, false, isFileSkipped(dir+"/__snapshots__", "skip_test.snap", "TestSkip"))
 		})
+
+		t.Run("should use regex match for runOnly", func(t *testing.T) {
+			dir, _ := os.Getwd()
+
+			test.Equal(t, false, isFileSkipped(dir+"/__snapshots__", "skip_test.snap", "	TestSkip.*"))
+		})
 	})
 }


### PR DESCRIPTION
Hey 👋 , I noticed an edge case issue on isFileSkipped. The `run` flag is accepting a regex but the 
isFileSkipped is doing an absolute match. I have seen there is a relevant fix but probably missed this point
https://github.com/gkampitakis/go-snaps/commit/9c6ad4b3de7f4ff998935124bd105535112daff8. 

So I changed to regex match and added a unit test.

Did also a minor change in testSkipped, shouldn't affect anything just moved the regex checking if a test
is skipped at the end just to defer the regex matching.