### PR TITLE
fix: skip creating multiple same snaspshots

### DIFF
--- a/snaps/clean.go
+++ b/snaps/clean.go
@@ -90,7 +90,7 @@ skipped. (We do that by checking if the mod is imported and there is a call to
 and we mark it as one.
 */
 func examineFiles(
-	registry map[string]map[string]int,
+	registry map[string]map[string]*testRuns,
 	runOnly string,
 	shouldUpdate bool,
 ) (obsolete, used []string) {
@@ -136,7 +136,7 @@ func examineFiles(
 }
 
 func examineSnaps(
-	registry map[string]map[string]int,
+	registry map[string]map[string]*testRuns,
 	used []string,
 	runOnly string,
 	shouldUpdate bool,
@@ -313,15 +313,15 @@ e.g
 
 as it means there are 3 snapshots created inside TestAdd
 */
-func occurrences(tests map[string]int) set {
+func occurrences(tests map[string]*testRuns) set {
 	result := make(set, len(tests))
-	for testID, counter := range tests {
-		if counter > 1 {
-			for i := 1; i <= counter; i++ {
+	for testID, run := range tests {
+		if run.times > 1 {
+			for i := 1; i <= run.times; i++ {
 				result[fmt.Sprintf("%s - %d", testID, i)] = struct{}{}
 			}
 		}
-		result[fmt.Sprintf("%s - %d", testID, counter)] = struct{}{}
+		result[fmt.Sprintf("%s - %d", testID, run.times)] = struct{}{}
 	}
 
 	return result

--- a/snaps/clean_test.go
+++ b/snaps/clean_test.go
@@ -61,7 +61,7 @@ string hello world 2 2 1
 
 `
 
-func setupTempExamineFiles(t *testing.T) (map[string]map[string]int, string, string) {
+func setupTempExamineFiles(t *testing.T) (map[string]map[string]*testRuns, string, string) {
 	t.Helper()
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
@@ -99,15 +99,17 @@ func setupTempExamineFiles(t *testing.T) (map[string]map[string]int, string, str
 		}
 	}
 
-	tests := map[string]map[string]int{
+	tests := map[string]map[string]*testRuns{
 		files[0].name: {
-			"TestDir1_1/TestSimple": 1,
-			"TestDir1_2/TestSimple": 1,
-			"TestDir1_3/TestSimple": 2,
+			"TestDir1_1/TestSimple": &testRuns{
+				times: 1,
+			},
+			"TestDir1_2/TestSimple": &testRuns{times: 1},
+			"TestDir1_3/TestSimple": &testRuns{times: 2},
 		},
 		files[1].name: {
-			"TestDir2_1/TestSimple": 3,
-			"TestDir2_2/TestSimple": 1,
+			"TestDir2_1/TestSimple": &testRuns{times: 3},
+			"TestDir2_2/TestSimple": &testRuns{times: 1},
 		},
 	}
 
@@ -194,7 +196,7 @@ func TestExamineSnaps(t *testing.T) {
 		shouldUpdate := false
 
 		// Reducing test occurrence to 1 meaning the second test was removed ( testid - 2 )
-		tests[used[0]]["TestDir1_3/TestSimple"] = 1
+		tests[used[0]]["TestDir1_3/TestSimple"].times = 1
 		// Removing the test entirely
 		delete(tests[used[1]], "TestDir2_2/TestSimple")
 
@@ -264,19 +266,19 @@ string hello world 2 2 1
 }
 
 func TestOccurrences(t *testing.T) {
-	tests := map[string]int{
-		"add":      3,
-		"subtract": 1,
-		"divide":   2,
+	tests := map[string]*testRuns{
+		"TestArithmetic/should add":      {times: 3},
+		"TestArithmetic/should subtract": {times: 1},
+		"TestArithmetic/should divide":   {times: 2},
 	}
 
 	expected := set{
-		"add - 1":      {},
-		"add - 2":      {},
-		"add - 3":      {},
-		"subtract - 1": {},
-		"divide - 1":   {},
-		"divide - 2":   {},
+		"TestArithmetic/should add - 1":      {},
+		"TestArithmetic/should add - 2":      {},
+		"TestArithmetic/should add - 3":      {},
+		"TestArithmetic/should subtract - 1": {},
+		"TestArithmetic/should divide - 1":   {},
+		"TestArithmetic/should divide - 2":   {},
 	}
 
 	test.Equal(t, expected, occurrences(tests))

--- a/snaps/matchJSON.go
+++ b/snaps/matchJSON.go
@@ -63,8 +63,8 @@ func MatchJSON(t testingT, input interface{}, matchers ...match.JSONMatcher) {
 func matchJSON(c *config, t testingT, input interface{}, matchers ...match.JSONMatcher) {
 	t.Helper()
 
-	dir, snapPath := snapDirAndName(c)
-	testID := testsRegistry.getTestID(t.Name(), snapPath)
+	dir, snapPath, line := snapDirAndName(c)
+	testID := testsRegistry.getTestID(t.Name(), snapPath, line)
 
 	j, err := validateJSON(input)
 	if err != nil {

--- a/snaps/matchSnapshot.go
+++ b/snaps/matchSnapshot.go
@@ -53,8 +53,8 @@ func matchSnapshot(c *config, t testingT, values ...interface{}) {
 		return
 	}
 
-	dir, snapPath := snapDirAndName(c)
-	testID := testsRegistry.getTestID(t.Name(), snapPath)
+	dir, snapPath, line := snapDirAndName(c)
+	testID := testsRegistry.getTestID(t.Name(), snapPath, line)
 	snapshot := takeSnapshot(values)
 	prevSnapshot, err := getPrevSnapshot(testID, snapPath)
 	if errors.Is(err, errSnapNotFound) {

--- a/snaps/skip_test.go
+++ b/snaps/skip_test.go
@@ -145,11 +145,10 @@ func TestSkip(t *testing.T) {
 				// This is for populating skippedTests.values and following the normal flow
 				SkipNow(mockT)
 
-				test.True(t, testSkipped("TestMock/Skip", runOnly))
-				test.Equal(
+				test.True(t, testSkipped("TestMock/Skip - 1000", runOnly))
+				test.True(
 					t,
-					true,
-					testSkipped("TestMock/Skip/child_should_also_be_skipped", runOnly),
+					testSkipped("TestMock/Skip/child_should_also_be_skipped - 100", runOnly),
 				)
 				test.False(t, testSkipped("TestAnotherTest", runOnly))
 			},
@@ -174,10 +173,10 @@ func TestSkip(t *testing.T) {
 			// This is for populating skippedTests.values and following the normal flow
 			SkipNow(mockT)
 
-			test.True(t, testSkipped("Test", runOnly))
-			test.True(t, testSkipped("Test/chid", runOnly))
-			test.False(t, testSkipped("TestMock", runOnly))
-			test.False(t, testSkipped("TestMock/child", runOnly))
+			test.True(t, testSkipped("Test - 1", runOnly))
+			test.True(t, testSkipped("Test/child - 1", runOnly))
+			test.False(t, testSkipped("TestMock - 1", runOnly))
+			test.False(t, testSkipped("TestMock/child - 1", runOnly))
 		})
 
 		t.Run("should use regex match for runOnly", func(t *testing.T) {

--- a/snaps/utils.go
+++ b/snaps/utils.go
@@ -73,32 +73,34 @@ func newSyncSlice() *syncSlice {
 	}
 }
 
-// Returns the path where the "user" tests are running
-func baseCaller(skip int) string {
+// Returns the path and the line where the "user" tests are running
+func baseCaller(skip int) (string, int) {
 	var (
 		pc             uintptr
 		file, prevFile string
+		line, prevLine int
 		ok             bool
 	)
 
 	for i := skip + 1; ; i++ {
 		prevFile = file
-		pc, file, _, ok = runtime.Caller(i)
+		prevLine = line
+		pc, file, line, ok = runtime.Caller(i)
 		if !ok {
-			return prevFile
+			return prevFile, prevLine
 		}
 
 		f := runtime.FuncForPC(pc)
 		if f == nil {
-			return prevFile
+			return prevFile, prevLine
 		}
 
 		if f.Name() == "testing.tRunner" {
-			return prevFile
+			return prevFile, prevLine
 		}
 
 		if strings.HasSuffix(filepath.Base(file), "_test.go") {
-			return file
+			return file, line
 		}
 	}
 }

--- a/snaps/utils_test.go
+++ b/snaps/utils_test.go
@@ -7,33 +7,38 @@ import (
 )
 
 func TestBaseCallerNested(t *testing.T) {
-	file := baseCaller(0)
+	file, line := baseCaller(0)
 
 	test.Contains(t, file, "/snaps/utils_test.go")
+	test.Equal(t, 10, line)
 }
 
 func testBaseCallerNested(t *testing.T) {
-	file := baseCaller(0)
+	file, line := baseCaller(0)
 
 	test.Contains(t, file, "/snaps/utils_test.go")
+	test.Equal(t, 17, line)
 }
 
 func TestBaseCallerHelper(t *testing.T) {
 	t.Helper()
-	file := baseCaller(0)
+	file, line := baseCaller(0)
 
 	test.Contains(t, file, "/snaps/utils_test.go")
+	test.Equal(t, 25, line)
 }
 
 func TestBaseCaller(t *testing.T) {
 	t.Run("should return correct baseCaller", func(t *testing.T) {
 		var file string
+		var line int
 
 		func() {
-			file = baseCaller(1)
+			file, line = baseCaller(1)
 		}()
 
 		test.Contains(t, file, "/snaps/utils_test.go")
+		test.Equal(t, 38, line)
 	})
 
 	t.Run("should return parent function", func(t *testing.T) {


### PR DESCRIPTION
When running tests with `count >= 2` multiple snapshots ( >=2 ) are created from the same call. This is a design flag IMO. 

My expectation is when someone runs golang tests with count > -2 wants to run the tests repeatedly and assert the data with the same snasphots and not create new ones.

This is a **BREAKING CHANGE** from the point of view that the library will stop having the same behaviour. Old tests should still keep passing but if people run their tests with count >= 2 then some of the snapshots will no longer be used for assertions and will be useless.