### PR TITLE
experimenting with inline snapshot support

### DIFF
--- a/snaps/matchInline.go
+++ b/snaps/matchInline.go
@@ -1,0 +1,126 @@
+package snaps
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"strings"
+
+	"github.com/kr/pretty"
+)
+
+type InlineSnapshot *string
+
+func Inline(s string) InlineSnapshot {
+	return &s
+}
+
+func MatchInlineSnapshot(t testingT, received interface{}, inlineSnap InlineSnapshot) {
+	t.Helper()
+	snapshot := pretty.Sprint(received)
+	filename, line := baseCaller(1)
+
+	if inlineSnap == nil {
+		if isCI {
+			handleError(t, errSnapNotFound)
+			return
+		}
+
+		if err := injectSnapshot(filename, line, snapshot); err != nil {
+			handleError(t, errSnapNotFound)
+		}
+		return
+	}
+
+	diff := prettyDiff(*inlineSnap, snapshot, "", -1)
+	if diff == "" {
+		testEvents.register(passed)
+		return
+	}
+
+	if !shouldUpdateSingle(t.Name()) {
+		handleError(t, diff)
+		return
+	}
+
+	if err := injectSnapshot(filename, line, snapshot); err != nil {
+		handleError(t, errSnapNotFound)
+		return
+	}
+
+	t.Log(updatedMsg)
+	testEvents.register(updated)
+}
+
+func injectSnapshot(filename string, line int, snapshot string) error {
+	foundCaller := false
+	fset := token.NewFileSet()
+	p, err := parser.ParseFile(
+		fset,
+		filename,
+		nil,
+		parser.ParseComments|parser.SkipObjectResolution,
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, decl := range p.Decls {
+		if funcDecl, ok := decl.(*ast.FuncDecl); ok {
+			if strings.HasPrefix(funcDecl.Name.Name, "Test") {
+				ast.Inspect(decl, func(n ast.Node) bool {
+					callExpr, ok := n.(*ast.CallExpr)
+					if ok {
+						selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+						if ok && selectorExpr.Sel.Name == "MatchInlineSnapshot" &&
+							fset.Position(n.Pos()).Line == line {
+							callExpr.Args[2] = createInlineArgument(snapshot)
+							foundCaller = true
+							return false
+						}
+					}
+
+					return true
+				})
+			}
+
+			if foundCaller {
+				break
+			}
+		}
+	}
+
+	if !foundCaller {
+		return errors.New("cannot locate caller")
+	}
+
+	file, err := os.OpenFile(filename, os.O_TRUNC|os.O_WRONLY, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return printer.Fprint(file, fset, p)
+}
+
+func createInlineArgument(s string) ast.Expr {
+	v := fmt.Sprintf("`%s`", s)
+	if isSingleline(s) {
+		v = fmt.Sprintf("%q", s)
+	}
+
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   &ast.Ident{Name: "snaps"},
+			Sel: &ast.Ident{Name: "Inline"},
+		},
+		Args: []ast.Expr{&ast.BasicLit{
+			Kind:  token.STRING,
+			Value: v,
+		}},
+	}
+}

--- a/snaps/matchInline.go
+++ b/snaps/matchInline.go
@@ -30,8 +30,8 @@ func MatchInlineSnapshot(t testingT, received interface{}, inlineSnap InlineSnap
 			return
 		}
 
-		if err := injectSnapshot(filename, line, snapshot); err != nil {
-			handleError(t, errSnapNotFound)
+		if err := writeInlineSnapshot(filename, line, snapshot); err != nil {
+			handleError(t, err)
 		}
 		return
 	}
@@ -47,8 +47,8 @@ func MatchInlineSnapshot(t testingT, received interface{}, inlineSnap InlineSnap
 		return
 	}
 
-	if err := injectSnapshot(filename, line, snapshot); err != nil {
-		handleError(t, errSnapNotFound)
+	if err := writeInlineSnapshot(filename, line, snapshot); err != nil {
+		handleError(t, err)
 		return
 	}
 
@@ -56,8 +56,7 @@ func MatchInlineSnapshot(t testingT, received interface{}, inlineSnap InlineSnap
 	testEvents.register(updated)
 }
 
-func injectSnapshot(filename string, line int, snapshot string) error {
-	foundCaller := false
+func writeInlineSnapshot(filename string, line int, snapshot string) error {
 	fset := token.NewFileSet()
 	p, err := parser.ParseFile(
 		fset,
@@ -70,41 +69,55 @@ func injectSnapshot(filename string, line int, snapshot string) error {
 	}
 
 	for _, decl := range p.Decls {
-		if funcDecl, ok := decl.(*ast.FuncDecl); ok {
-			if strings.HasPrefix(funcDecl.Name.Name, "Test") {
-				ast.Inspect(decl, func(n ast.Node) bool {
-					callExpr, ok := n.(*ast.CallExpr)
-					if ok {
-						selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
-						if ok && selectorExpr.Sel.Name == "MatchInlineSnapshot" &&
-							fset.Position(n.Pos()).Line == line {
-							callExpr.Args[2] = createInlineArgument(snapshot)
-							foundCaller = true
-							return false
-						}
-					}
-
-					return true
-				})
-			}
-
-			if foundCaller {
-				break
-			}
+		funcDecl, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
 		}
+		if !strings.HasPrefix(funcDecl.Name.Name, "Test") {
+			continue
+		}
+
+		if !updateAST(decl, fset, line, snapshot) {
+			continue
+		}
+
+		file, err := os.OpenFile(filename, os.O_TRUNC|os.O_WRONLY, os.ModePerm)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		return printer.Fprint(file, fset, p)
 	}
 
-	if !foundCaller {
-		return errors.New("cannot locate caller")
-	}
+	return errors.New("cannot locate caller")
+}
 
-	file, err := os.OpenFile(filename, os.O_TRUNC|os.O_WRONLY, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
+func updateAST(node ast.Node, fset *token.FileSet, line int, snapshot string) bool {
+	var updated bool
 
-	return printer.Fprint(file, fset, p)
+	ast.Inspect(node, func(n ast.Node) bool {
+		callExpr, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		if selectorExpr.Sel.Name == "MatchInlineSnapshot" &&
+			fset.Position(n.Pos()).Line == line {
+			callExpr.Args[2] = createInlineArgument(snapshot)
+			updated = true
+
+			return false
+		}
+
+		return true
+	})
+
+	return updated
 }
 
 func createInlineArgument(s string) ast.Expr {

--- a/snaps/matchInlineSnapshot.go
+++ b/snaps/matchInlineSnapshot.go
@@ -15,11 +15,48 @@ import (
 
 type InlineSnapshot *string
 
+// Inline representation of snapshot
 func Inline(s string) InlineSnapshot {
 	return &s
 }
 
+/*
+MatchInlineSnapshot verifies the value matches the inline snapshot
+First you call it with nil
+
+	MatchInlineSnapshot(t, "mysnapshot", nil)
+
+and it populates with the snapshot
+
+	MatchInlineSnapshot(t, "mysnapshot", snaps.Inline("mysnapshot"))
+
+the on every subsequent call it verifies the value matches the snapshot
+*/
+func (c *config) MatchInlineSnapshot(t testingT, received interface{}, inlineSnap InlineSnapshot) {
+	t.Helper()
+
+	matchInlineSnapshot(c, t, received, inlineSnap)
+}
+
+/*
+MatchInlineSnapshot verifies the value matches the inline snapshot
+First you call it with nil
+
+	MatchInlineSnapshot(t, "mysnapshot", nil)
+
+and it populates with the snapshot
+
+	MatchInlineSnapshot(t, "mysnapshot", snaps.Inline("mysnapshot"))
+
+the on every subsequent call it verifies the value matches the snapshot
+*/
 func MatchInlineSnapshot(t testingT, received interface{}, inlineSnap InlineSnapshot) {
+	t.Helper()
+
+	matchInlineSnapshot(&defaultConfig, t, received, inlineSnap)
+}
+
+func matchInlineSnapshot(c *config, t testingT, received interface{}, inlineSnap InlineSnapshot) {
 	t.Helper()
 	snapshot := pretty.Sprint(received)
 	filename, line := baseCaller(1)
@@ -42,7 +79,7 @@ func MatchInlineSnapshot(t testingT, received interface{}, inlineSnap InlineSnap
 		return
 	}
 
-	if !shouldUpdateSingle(t.Name()) {
+	if !shouldUpdate(c.update) {
 		handleError(t, diff)
 		return
 	}

--- a/snaps/matchInlineSnapshot_test.go
+++ b/snaps/matchInlineSnapshot_test.go
@@ -1,0 +1,7 @@
+package snaps
+
+import "testing"
+
+func TestMatchInlineSnapshot(t *testing.T) {
+	t.Error("unimplemented")
+}

--- a/snaps/snapshot.go
+++ b/snaps/snapshot.go
@@ -241,7 +241,7 @@ Returns the relative path of the caller and the snapshot path.
 */
 func snapshotPath(c *config) (string, string) {
 	//  skips current func, the wrapper match* and the exported Match* func
-	callerPath := baseCaller(3)
+	callerPath, _ := baseCaller(3)
 
 	dir := c.snapsDir
 	if !filepath.IsAbs(dir) {

--- a/snaps/utils.go
+++ b/snaps/utils.go
@@ -76,31 +76,33 @@ func newSyncSlice() *syncSlice {
 }
 
 // Returns the path where the "user" tests are running
-func baseCaller(skip int) string {
+func baseCaller(skip int) (string, int) {
 	var (
 		pc             uintptr
 		file, prevFile string
+		line, prevLine int
 		ok             bool
 	)
 
 	for i := skip + 1; ; i++ {
+		prevLine = line
 		prevFile = file
-		pc, file, _, ok = runtime.Caller(i)
+		pc, file, line, ok = runtime.Caller(i)
 		if !ok {
-			return prevFile
+			return prevFile, prevLine
 		}
 
 		f := runtime.FuncForPC(pc)
 		if f == nil {
-			return prevFile
+			return prevFile, prevLine
 		}
 
 		if f.Name() == "testing.tRunner" {
-			return prevFile
+			return prevFile, prevLine
 		}
 
 		if strings.HasSuffix(filepath.Base(file), "_test.go") {
-			return file
+			return file, line
 		}
 	}
 }

--- a/snaps/utils_test.go
+++ b/snaps/utils_test.go
@@ -7,20 +7,23 @@ import (
 )
 
 func TestBaseCallerNested(t *testing.T) {
-	file := baseCaller(0)
+	file, _ := baseCaller(0)
+	t.Error("fix line")
 
 	test.Contains(t, file, "/snaps/utils_test.go")
 }
 
 func testBaseCallerNested(t *testing.T) {
-	file := baseCaller(0)
+	file, _ := baseCaller(0)
+	t.Error("fix line")
 
 	test.Contains(t, file, "/snaps/utils_test.go")
 }
 
 func TestBaseCallerHelper(t *testing.T) {
 	t.Helper()
-	file := baseCaller(0)
+	file, _ := baseCaller(0)
+	t.Error("fix line")
 
 	test.Contains(t, file, "/snaps/utils_test.go")
 }
@@ -30,7 +33,8 @@ func TestBaseCaller(t *testing.T) {
 		var file string
 
 		func() {
-			file = baseCaller(1)
+			t.Error("fix line")
+			file, _ = baseCaller(1)
 		}()
 
 		test.Contains(t, file, "/snaps/utils_test.go")


### PR DESCRIPTION
The api right now looks like


Calling the first time

```go
t.Run("my test", func(t *testing.T) {
user := struct{ Name string }{
	Name: "george",
}

snaps.MatchInlineSnapshot(t, user, nil)
})
```

and then it will populate with the snapshot data

```go
t.Run("my test", func(t *testing.T) {
user := struct{ Name string }{
	Name: "george",
}

snaps.MatchInlineSnapshot(t, user, snaps.Inline("struct { Name string }{Name:\"george\"}"))
})
```

Still haven't investigated all the edge cases that this can have and I can see being useful but not sure how much is it worth it.


Two issues that are not addressed

- [ ] Long line snapshots, haven't found a way to split text to multiples lines
- [ ] Comments ast parsing