### PR TITLE
fix: detect if running from vscode

### DIFF
--- a/internal/colors/colors.go
+++ b/internal/colors/colors.go
@@ -30,8 +30,10 @@ var NOCOLOR = isNoColor()
 
 func isNoColor() bool {
 	// https://no-color.org (with any value)
-	_, ok := os.LookupEnv("NO_COLOR")
-	return ok
+	_, noColor := os.LookupEnv("NO_COLOR")
+	// hacky way but should be good enough to support diff on vscode output panel
+	term := strings.ToLower(os.Getenv("_"))
+	return noColor || strings.Contains(term, "visual") || strings.Contains(term, "code")
 }
 
 func Sprint(color, s string) string {


### PR DESCRIPTION
A naive implementation of detecting if colour is supported but works at least for my case on VS Code. 

Before when running VS Code test from extension
<img width="1286" alt="Screenshot 2023-11-03 at 18 03 40" src="https://github.com/gkampitakis/go-snaps/assets/50364739/6861aed9-a7ed-463f-894a-d2eaf0d22ea8">

With this pr

<img width="857" alt="Screenshot 2023-11-03 at 18 07 25" src="https://github.com/gkampitakis/go-snaps/assets/50364739/49711b91-edab-4d19-a817-2906b43aef86">
