### PR TITLE
fix: replace `Print` with `Println`

### DIFF
--- a/snaps/clean.go
+++ b/snaps/clean.go
@@ -106,7 +106,7 @@ func Clean(m *testing.M, opts ...CleanOpts) {
 		testEvents.items,
 		shouldClean && !isCI,
 	); s != "" {
-		fmt.Print(s)
+		fmt.Printf("%s\n", s)
 	}
 }
 

--- a/snaps/clean.go
+++ b/snaps/clean.go
@@ -106,7 +106,7 @@ func Clean(m *testing.M, opts ...CleanOpts) {
 		testEvents.items,
 		shouldClean && !isCI,
 	); s != "" {
-		fmt.Printf("%s\n", s)
+		fmt.Println(s)
 	}
 }
 


### PR DESCRIPTION
This is a weird one I'm still digging into but since adding `go-snaps` we're getting newlines in our test output:

```
osv-detector on  use-go-snaps [!?] via 🐹 v1.21.5 via  v20.11.0 took 3s
❯ make test
go test ./...
?       github.com/g-rath/osv-detector/internal [no test files]
?       github.com/g-rath/osv-detector/internal/cachedregexp    [no test files]

ok      github.com/g-rath/osv-detector  3.341s
ok      github.com/g-rath/osv-detector/internal/configer        (cached)
ok      github.com/g-rath/osv-detector/internal/reporter        (cached)
ok      github.com/g-rath/osv-detector/pkg/database     (cached)
ok      github.com/g-rath/osv-detector/pkg/lockfile     (cached)
ok      github.com/g-rath/osv-detector/pkg/semantic     (cached)
```

I've traced this down to the use of `snaps.Clean` and specifically this `fmt.Print` call - weirdly, if I replace it with this change the newline goes away but not if I do e.g. `fmt.Printf(s)`:

```
osv-detector on  use-go-snaps [!?] via 🐹 v1.21.5 via  v20.11.0 took 3s
❯ make test
go test ./...
?       github.com/g-rath/osv-detector/internal [no test files]
?       github.com/g-rath/osv-detector/internal/cachedregexp    [no test files]
ok      github.com/g-rath/osv-detector  3.172s
ok      github.com/g-rath/osv-detector/internal/configer        (cached)
ok      github.com/g-rath/osv-detector/internal/reporter        (cached)
ok      github.com/g-rath/osv-detector/pkg/database     (cached)
ok      github.com/g-rath/osv-detector/pkg/lockfile     (cached)
ok      github.com/g-rath/osv-detector/pkg/semantic     (cached)
```

I think this actually might be a bug in Go, but I'm not brave enough to try taking that on 😅