### PR TITLE
fix: slice bounds out of range [:5]

### DIFF
--- a/snaps/clean.go
+++ b/snaps/clean.go
@@ -117,7 +117,7 @@ func getTestID(b []byte) (string, bool) {
 	}
 
 	// needs to start with [Test and end with ]
-	if !bytes.Equal(b[0:5], []byte("[Test")) || b[len(b)-1] != ']' {
+	if !bytes.HasPrefix(b, []byte("[Test")) || b[len(b)-1] != ']' {
 		return "", false
 	}
 

--- a/snaps/clean_test.go
+++ b/snaps/clean_test.go
@@ -448,6 +448,7 @@ func TestGetTestID(t *testing.T) {
 		// must have dash between test name and number
 		{"[Test something 10]", "", false},
 		{"[Test/something - not a number]", "", false},
+		{"s", "", false},
 	}
 
 	for _, tc := range testCases {
@@ -456,7 +457,11 @@ func TestGetTestID(t *testing.T) {
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
 
-			id, ok := getTestID([]byte(tc.input))
+			// make sure that the capacity of b is len(tc.input), this way
+			// indexing beyond the capacity will cause test to panic
+			b := make([]byte, 0, len(tc.input))
+			b = append(b, []byte(tc.input)...)
+			id, ok := getTestID(b)
 
 			test.Equal(t, tc.valid, ok)
 			test.Equal(t, tc.expectedID, id)


### PR DESCRIPTION
When the capacity of the given byte slice is less than 5 the `getTestID` function panics with:

```
panic: runtime error: slice bounds out of range [:5] with capacity 1 [recovered]
	panic: runtime error: slice bounds out of range [:5] with capacity 1
```

This uses `bytes.HasPrefix` instead which will check the bounds of the slice before comparing.