### PR TITLE
Add custom CI override functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,3 +429,17 @@ This library used [Jest Snapshoting](https://jestjs.io/docs/snapshot-testing) an
 
 > [!NOTE]
 > go-snaps doesn't handle CRLF line endings. If you are using Windows, you may need to convert the line endings to LF.
+
+## SetCustomCI
+
+`SetCustomCI` allows setting a custom CI environment.
+
+```go
+// Set custom CI to true
+snaps.SetCustomCI(true)
+
+// Set custom CI to false
+snaps.SetCustomCI(false)
+```
+
+This can be useful if you have a custom CI environment that is not detected by the `ciinfo` package.

--- a/snaps/utils.go
+++ b/snaps/utils.go
@@ -125,3 +125,8 @@ func shouldUpdate(u *bool) bool {
 
 	return updateVAR == "true"
 }
+
+// SetCustomCI allows setting a custom CI environment
+func SetCustomCI(customCI bool) {
+	isCI = customCI
+}

--- a/snaps/utils_test.go
+++ b/snaps/utils_test.go
@@ -44,3 +44,15 @@ func TestBaseCaller(t *testing.T) {
 		TestBaseCallerNested(t)
 	})
 }
+
+func TestSetCustomCI(t *testing.T) {
+	t.Run("should override isCI variable", func(t *testing.T) {
+		// Set custom CI to true
+		SetCustomCI(true)
+		test.True(t, isCI)
+
+		// Set custom CI to false
+		SetCustomCI(false)
+		test.False(t, isCI)
+	})
+}


### PR DESCRIPTION
Add functionality to override `isCI` variable for custom CI environments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gkampitakis/go-snaps/pull/116?shareId=febfb510-1f9b-4713-95b7-ccc8afbc5ade).