### PR TITLE
fix: snaps.Update should apply and on snapshot create

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ t.Run("snapshot tests", func(t *testing.T) {
   s := snaps.WithConfig(
     snaps.Dir("my_dir"),
     snaps.Filename("json_file"),
-    snaps.Ext(".json")
+    snaps.Ext(".json"),
     snaps.Update(false)
   )
 

--- a/snaps/matchJSON.go
+++ b/snaps/matchJSON.go
@@ -100,7 +100,7 @@ func matchJSON(c *Config, t testingT, input any, matchers ...match.JSONMatcher) 
 	snapshot := takeJSONSnapshot(j)
 	prevSnapshot, line, err := getPrevSnapshot(testID, snapPath)
 	if errors.Is(err, errSnapNotFound) {
-		if isCI {
+		if !shouldCreate(c.update) {
 			handleError(t, err)
 			return
 		}

--- a/snaps/matchJSON_test.go
+++ b/snaps/matchJSON_test.go
@@ -171,6 +171,19 @@ func TestMatchJSON(t *testing.T) {
 		test.Equal(t, 1, testEvents.items[erred])
 	})
 
+	t.Run("if snaps.Update(false) should skip creating snapshot", func(t *testing.T) {
+		setupSnapshot(t, fileName, false)
+
+		mockT := test.NewMockTestingT(t)
+		mockT.MockError = func(args ...any) {
+			test.Equal(t, errSnapNotFound, args[0].(error))
+		}
+
+		WithConfig(Update(false)).MatchJSON(mockT, "{}")
+
+		test.Equal(t, 1, testEvents.items[erred])
+	})
+
 	t.Run("should update snapshot when 'shouldUpdate'", func(t *testing.T) {
 		snapPath := setupSnapshot(t, jsonFilename, false, true)
 

--- a/snaps/matchSnapshot.go
+++ b/snaps/matchSnapshot.go
@@ -63,7 +63,7 @@ func matchSnapshot(c *Config, t testingT, values ...any) {
 	snapshot := takeSnapshot(values)
 	prevSnapshot, line, err := getPrevSnapshot(testID, snapPath)
 	if errors.Is(err, errSnapNotFound) {
-		if isCI {
+		if !shouldCreate(c.update) {
 			handleError(t, err)
 			return
 		}

--- a/snaps/matchSnapshot_test.go
+++ b/snaps/matchSnapshot_test.go
@@ -92,6 +92,19 @@ func TestMatchSnapshot(t *testing.T) {
 		test.Equal(t, 1, testEvents.items[erred])
 	})
 
+	t.Run("if snaps.Update(false) should skip creating snapshot", func(t *testing.T) {
+		setupSnapshot(t, fileName, false)
+
+		mockT := test.NewMockTestingT(t)
+		mockT.MockError = func(args ...any) {
+			test.Equal(t, errSnapNotFound, args[0].(error))
+		}
+
+		WithConfig(Update(false)).MatchSnapshot(mockT, 10, "hello world")
+
+		test.Equal(t, 1, testEvents.items[erred])
+	})
+
 	t.Run("should return error when diff is found", func(t *testing.T) {
 		setupSnapshot(t, fileName, false)
 

--- a/snaps/matchStandaloneJSON.go
+++ b/snaps/matchStandaloneJSON.go
@@ -70,7 +70,7 @@ func matchStandaloneJSON(c *Config, t testingT, input any, matchers ...match.JSO
 	snapshot := takeJSONSnapshot(j)
 	prevSnapshot, err := getPrevStandaloneSnapshot(snapPath)
 	if errors.Is(err, errSnapNotFound) {
-		if isCI {
+		if !shouldCreate(c.update) {
 			handleError(t, err)
 			return
 		}

--- a/snaps/matchStandaloneJSON_test.go
+++ b/snaps/matchStandaloneJSON_test.go
@@ -173,6 +173,19 @@ func TestMatchStandaloneJSON(t *testing.T) {
 		test.Equal(t, 1, testEvents.items[erred])
 	})
 
+	t.Run("if snaps.Update(false) should skip creating snapshot", func(t *testing.T) {
+		setupSnapshot(t, fileName, false)
+
+		mockT := test.NewMockTestingT(t)
+		mockT.MockError = func(args ...any) {
+			test.Equal(t, errSnapNotFound, args[0].(error))
+		}
+
+		WithConfig(Update(false)).MatchStandaloneJSON(mockT, "{}")
+
+		test.Equal(t, 1, testEvents.items[erred])
+	})
+
 	t.Run("should update snapshot when 'shouldUpdate'", func(t *testing.T) {
 		snapPath := setupSnapshot(t, jsonStandaloneFilename, false, true)
 

--- a/snaps/matchStandaloneSnapshot.go
+++ b/snaps/matchStandaloneSnapshot.go
@@ -50,7 +50,7 @@ func matchStandaloneSnapshot(c *Config, t testingT, input any) {
 	snapshot := pretty.Sprint(input)
 	prevSnapshot, err := getPrevStandaloneSnapshot(snapPath)
 	if errors.Is(err, errSnapNotFound) {
-		if isCI {
+		if !shouldCreate(c.update) {
 			handleError(t, err)
 			return
 		}

--- a/snaps/matchStandaloneSnapshot_test.go
+++ b/snaps/matchStandaloneSnapshot_test.go
@@ -72,6 +72,19 @@ func TestMatchStandaloneSnapshot(t *testing.T) {
 		test.Equal(t, 1, testEvents.items[erred])
 	})
 
+	t.Run("if snaps.Update(false) should skip creating snapshot", func(t *testing.T) {
+		setupSnapshot(t, fileName, false)
+
+		mockT := test.NewMockTestingT(t)
+		mockT.MockError = func(args ...any) {
+			test.Equal(t, errSnapNotFound, args[0].(error))
+		}
+
+		WithConfig(Update(false)).MatchStandaloneSnapshot(mockT, "hello world")
+
+		test.Equal(t, 1, testEvents.items[erred])
+	})
+
 	t.Run("should return error when diff is found", func(t *testing.T) {
 		setupSnapshot(t, standaloneFilename, false)
 

--- a/snaps/matchYAML.go
+++ b/snaps/matchYAML.go
@@ -95,7 +95,7 @@ func matchYAML(c *Config, t testingT, input any, matchers ...match.YAMLMatcher) 
 	snapshot := takeYAMLSnapshot(y)
 	prevSnapshot, line, err := getPrevSnapshot(testID, snapPath)
 	if errors.Is(err, errSnapNotFound) {
-		if isCI {
+		if !shouldCreate(c.update) {
 			handleError(t, err)
 			return
 		}

--- a/snaps/matchYAML_test.go
+++ b/snaps/matchYAML_test.go
@@ -172,6 +172,19 @@ items:
 			test.Equal(t, 1, testEvents.items[erred])
 		})
 
+		t.Run("if snaps.Update(false) should skip creating snapshot", func(t *testing.T) {
+			setupSnapshot(t, fileName, false)
+
+			mockT := test.NewMockTestingT(t)
+			mockT.MockError = func(args ...any) {
+				test.Equal(t, errSnapNotFound, args[0].(error))
+			}
+
+			WithConfig(Update(false)).MatchYAML(mockT, "")
+
+			test.Equal(t, 1, testEvents.items[erred])
+		})
+
 		t.Run("should update snapshot when 'shouldUpdate'", func(t *testing.T) {
 			snapPath := setupSnapshot(t, yamlFilename, false, true)
 			printerExpectedCalls := []func(received any){

--- a/snaps/utils.go
+++ b/snaps/utils.go
@@ -125,3 +125,16 @@ func shouldUpdate(u *bool) bool {
 
 	return updateVAR == "true"
 }
+
+// shouldCreate determines whether snapshots should be created
+func shouldCreate(u *bool) bool {
+	if isCI {
+		return false
+	}
+
+	if u != nil {
+		return *u
+	}
+
+	return true
+}


### PR DESCRIPTION
Closes https://github.com/gkampitakis/go-snaps/pull/116, where when we want to "disable" the first update (or creation) there is no way apart from running on CI.