### PR TITLE
feat: add json format config

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ You can see more [examples](./examples/matchJSON_test.go#L96).
 - the filename where snapshots are stored
 - the snapshot file's extension (_regardless the extension the filename will include the `.snaps` inside the filename_)
 - programmatically control whether to update snapshots. _You can find an example usage at [examples](/examples/examples_test.go#13)_
+- json config's json format configuration:
+  - `Width`: The maximum width in characters before wrapping json output (default: 80)
+  - `Indent`: The indentation string to use for nested structures (default: 1 spaces)
+  - `SortKeys`: Whether to sort json object keys alphabetically (default: true)
 
 ```go
 t.Run("snapshot tests", func(t *testing.T) {
@@ -283,7 +287,12 @@ t.Run("snapshot tests", func(t *testing.T) {
     snaps.Dir("my_dir"),
     snaps.Filename("json_file"),
     snaps.Ext(".json"),
-    snaps.Update(false)
+    snaps.Update(false),
+    snaps.JSON(snaps.JSONConfig{
+      Width:    80,
+      Indent:   "    ",
+      SortKeys: false,
+    }),
   )
 
   s.MatchJSON(t, `{"hello":"world"}`)

--- a/examples/__snapshots__/TestMatchStandaloneJSON_should_create_a_prettyJSON_snap_following_by_config_1.snap.json
+++ b/examples/__snapshots__/TestMatchStandaloneJSON_should_create_a_prettyJSON_snap_following_by_config_1.snap.json
@@ -1,0 +1,5 @@
+{
+    "user": "mock-user",
+    "age": 10,
+    "email": "mock@email.com"
+}

--- a/examples/__snapshots__/TestMatchStandaloneJSON_should_create_a_prettyJSON_snap_following_by_config_2.snap.json
+++ b/examples/__snapshots__/TestMatchStandaloneJSON_should_create_a_prettyJSON_snap_following_by_config_2.snap.json
@@ -1,0 +1,5 @@
+{
+    "user": "mock-user",
+    "age": 10,
+    "email": "mock@email.com"
+}

--- a/examples/__snapshots__/matchJSON_test.snap
+++ b/examples/__snapshots__/matchJSON_test.snap
@@ -100,3 +100,19 @@
  "metadata": "<Type:map[string]interface {}>"
 }
 ---
+
+[TestMatchJSON/should_create_a_prettyJSON_snap_following_by_config - 1]
+{
+    "user": "mock-user",
+    "age": 10,
+    "email": "mock@email.com"
+}
+---
+
+[TestMatchJSON/should_create_a_prettyJSON_snap_following_by_config - 2]
+{
+    "user": "mock-user",
+    "age": 10,
+    "email": "mock@email.com"
+}
+---

--- a/examples/matchJSON_test.go
+++ b/examples/matchJSON_test.go
@@ -91,6 +91,16 @@ func TestMatchJSON(t *testing.T) {
 
 		snaps.MatchJSON(t, u)
 	})
+
+	t.Run("should create a prettyJSON snap following by config", func(t *testing.T) {
+		value := `{"user":"mock-user","age":10,"email":"mock@email.com"}`
+		config := snaps.WithConfig(snaps.JSON(snaps.JSONConfig{
+			Indent:   "    ",
+			SortKeys: false,
+		}))
+		config.MatchJSON(t, value)
+		config.MatchJSON(t, []byte(value))
+	})
 }
 
 func TestMatchers(t *testing.T) {

--- a/examples/matchJSON_test.go
+++ b/examples/matchJSON_test.go
@@ -94,12 +94,12 @@ func TestMatchJSON(t *testing.T) {
 
 	t.Run("should create a prettyJSON snap following by config", func(t *testing.T) {
 		value := `{"user":"mock-user","age":10,"email":"mock@email.com"}`
-		config := snaps.WithConfig(snaps.JSON(snaps.JSONConfig{
+		s := snaps.WithConfig(snaps.JSON(snaps.JSONConfig{
 			Indent:   "    ",
 			SortKeys: false,
 		}))
-		config.MatchJSON(t, value)
-		config.MatchJSON(t, []byte(value))
+		s.MatchJSON(t, value)
+		s.MatchJSON(t, []byte(value))
 	})
 }
 

--- a/examples/matchStandaloneJSON_test.go
+++ b/examples/matchStandaloneJSON_test.go
@@ -45,12 +45,12 @@ func TestMatchStandaloneJSON(t *testing.T) {
 
 	t.Run("should create a prettyJSON snap following by config", func(t *testing.T) {
 		value := `{"user":"mock-user","age":10,"email":"mock@email.com"}`
-		config := snaps.WithConfig(snaps.JSON(snaps.JSONConfig{
+		s := snaps.WithConfig(snaps.JSON(snaps.JSONConfig{
 			Indent:   "    ",
 			SortKeys: false,
 		}))
-		config.MatchStandaloneJSON(t, value)
-		config.MatchStandaloneJSON(t, []byte(value))
+		s.MatchStandaloneJSON(t, value)
+		s.MatchStandaloneJSON(t, []byte(value))
 	})
 
 	t.Run("matchers", func(t *testing.T) {

--- a/examples/matchStandaloneJSON_test.go
+++ b/examples/matchStandaloneJSON_test.go
@@ -43,6 +43,16 @@ func TestMatchStandaloneJSON(t *testing.T) {
 		snaps.MatchStandaloneJSON(t, u)
 	})
 
+	t.Run("should create a prettyJSON snap following by config", func(t *testing.T) {
+		value := `{"user":"mock-user","age":10,"email":"mock@email.com"}`
+		config := snaps.WithConfig(snaps.JSON(snaps.JSONConfig{
+			Indent:   "    ",
+			SortKeys: false,
+		}))
+		config.MatchStandaloneJSON(t, value)
+		config.MatchStandaloneJSON(t, []byte(value))
+	})
+
 	t.Run("matchers", func(t *testing.T) {
 		t.Run("Custom matcher", func(t *testing.T) {
 			t.Run("struct marshalling", func(t *testing.T) {

--- a/snaps/matchJSON.go
+++ b/snaps/matchJSON.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	jsonOptions = &pretty.Options{
+	defaultPrettyJSONOptions = &pretty.Options{
 		SortKeys: true,
 		Indent:   " ",
 	}
@@ -97,7 +97,7 @@ func matchJSON(c *Config, t testingT, input any, matchers ...match.JSONMatcher) 
 		return
 	}
 
-	snapshot := takeJSONSnapshot(j)
+	snapshot := takeJSONSnapshot(c, j)
 	prevSnapshot, line, err := getPrevSnapshot(testID, snapPath)
 	if errors.Is(err, errSnapNotFound) {
 		if !shouldCreate(c.update) {
@@ -159,8 +159,8 @@ func validateJSON(input any) ([]byte, error) {
 	}
 }
 
-func takeJSONSnapshot(b []byte) string {
-	return strings.TrimSuffix(string(pretty.PrettyOptions(b, jsonOptions)), "\n")
+func takeJSONSnapshot(c *Config, b []byte) string {
+	return strings.TrimSuffix(string(pretty.PrettyOptions(b, c.json.getPrettyJSONOptions())), "\n")
 }
 
 func applyJSONMatchers(b []byte, matchers ...match.JSONMatcher) ([]byte, []match.MatcherError) {

--- a/snaps/matchStandaloneJSON.go
+++ b/snaps/matchStandaloneJSON.go
@@ -67,7 +67,7 @@ func matchStandaloneJSON(c *Config, t testingT, input any, matchers ...match.JSO
 		return
 	}
 
-	snapshot := takeJSONSnapshot(j)
+	snapshot := takeJSONSnapshot(c, j)
 	prevSnapshot, err := getPrevStandaloneSnapshot(snapPath)
 	if errors.Is(err, errSnapNotFound) {
 		if !shouldCreate(c.update) {

--- a/snaps/snapshot.go
+++ b/snaps/snapshot.go
@@ -34,7 +34,6 @@ type Config struct {
 	json      *JSONConfig
 }
 
-// TODO: Revise this comments
 type JSONConfig struct {
 	// Width is a max column width for single line arrays
 	// Default: see defaultPrettyJSONOptions.Width for detail
@@ -101,7 +100,7 @@ func Ext(ext string) func(*Config) {
 	}
 }
 
-// Specify json configuration
+// Specify json format configuration
 //
 // default: see defaultPrettyJSONOptions for default json config
 func JSON(json JSONConfig) func(*Config) {

--- a/snaps/snapshot.go
+++ b/snaps/snapshot.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/gkampitakis/go-snaps/internal/colors"
+	"github.com/tidwall/pretty"
 )
 
 var (
@@ -30,6 +31,31 @@ type Config struct {
 	snapsDir  string
 	extension string
 	update    *bool
+	json      *JSONConfig
+}
+
+// TODO: Revise this comments
+type JSONConfig struct {
+	// Width is a max column width for single line arrays
+	// Default: see defaultPrettyJSONOptions.Width for detail
+	Width int
+	// Indent is the nested indentation
+	// Default: see defaultPrettyJSONOptions.Indent for detail
+	Indent string
+	// SortKeys will sort the keys alphabetically
+	// Default: see defaultPrettyJSONOptions.SortKeys for detail
+	SortKeys bool
+}
+
+func (j *JSONConfig) getPrettyJSONOptions() *pretty.Options {
+	if j == nil {
+		return defaultPrettyJSONOptions
+	}
+	return &pretty.Options{
+		Width:    j.Width,
+		Indent:   j.Indent,
+		SortKeys: j.SortKeys,
+	}
 }
 
 // Update determines whether to update snapshots or not
@@ -72,6 +98,15 @@ func Dir(dir string) func(*Config) {
 func Ext(ext string) func(*Config) {
 	return func(c *Config) {
 		c.extension = ext
+	}
+}
+
+// Specify json configuration
+//
+// default: see defaultPrettyJSONOptions for default json config
+func JSON(json JSONConfig) func(*Config) {
+	return func(c *Config) {
+		c.json = &json
 	}
 }
 


### PR DESCRIPTION
Hello guys.

I'd like to propose add json format config into `snaps.Config`. for custom json formatting when take the snapshot. 

example json format config
```go
 s := snaps.WithConfig(
    snaps.JSON(snaps.JSONConfig{
      Width:    80,
      Indent:   "    ",
      SortKeys: false,
    }),
  )

s.MatchJSON(t, value)
s.MatchStandaloneJSON(t, value)
``` 