### PR TITLE
fix: only update snapshots when actually allowed

### DIFF
--- a/snaps/clean.go
+++ b/snaps/clean.go
@@ -293,12 +293,14 @@ func examineSnaps(
 		}
 
 		shouldSort := sort && !slices.IsSortedFunc(testIDs, naturalSort)
-		isDirty = isDirty || (hasDiffs && !update) || (shouldSort && isCI)
 
-		shouldDelete := update && hasDiffs
+		// if we're not allowed to update anything, just capture if the snapshot
+		// needs cleaning, and then continue to the next snapshot
+		if !update {
+			if hasDiffs || shouldSort {
+				isDirty = true
+			}
 
-		// if we don't have to "write" anything on the snap we skip
-		if !shouldDelete && !shouldSort {
 			f.Close()
 
 			clear(tests)

--- a/snaps/clean.go
+++ b/snaps/clean.go
@@ -293,7 +293,7 @@ func examineSnaps(
 		}
 
 		shouldSort := sort && !slices.IsSortedFunc(testIDs, naturalSort)
-		isDirty = isDirty || hasDiffs || (shouldSort && isCI)
+		isDirty = isDirty || (hasDiffs && !update) || (shouldSort && isCI)
 
 		shouldDelete := update && hasDiffs
 

--- a/snaps/clean.go
+++ b/snaps/clean.go
@@ -236,7 +236,7 @@ func examineSnaps(
 	used []string,
 	runOnly string,
 	count int,
-	update,
+	shouldUpdate,
 	sort bool,
 ) ([]string, bool, error) {
 	obsoleteTests := []string{}
@@ -251,7 +251,7 @@ func examineSnaps(
 			return nil, isDirty, err
 		}
 
-		var hasDiffs bool
+		var needsUpdating bool
 
 		registeredTests := occurrences(registry[snapPath], count, snapshotOccurrenceFMT)
 		s := snapshotScanner(f)
@@ -267,7 +267,7 @@ func examineSnaps(
 
 			if !registeredTests.Has(testID) && !testSkipped(testID, runOnly) {
 				obsoleteTests = append(obsoleteTests, testID)
-				hasDiffs = true
+				needsUpdating = true
 
 				removeSnapshot(s)
 				continue
@@ -292,12 +292,12 @@ func examineSnaps(
 			return nil, isDirty, err
 		}
 
-		shouldSort := sort && !slices.IsSortedFunc(testIDs, naturalSort)
+		needsSorting := sort && !slices.IsSortedFunc(testIDs, naturalSort)
 
 		// if we're not allowed to update anything, just capture if the snapshot
 		// needs cleaning, and then continue to the next snapshot
-		if !update {
-			if hasDiffs || shouldSort {
+		if !shouldUpdate {
+			if needsUpdating || needsSorting {
 				isDirty = true
 			}
 
@@ -310,7 +310,7 @@ func examineSnaps(
 			continue
 		}
 
-		if shouldSort {
+		if needsSorting {
 			// sort testIDs
 			slices.SortFunc(testIDs, naturalSort)
 		}

--- a/snaps/clean.go
+++ b/snaps/clean.go
@@ -292,10 +292,10 @@ func examineSnaps(
 			return nil, isDirty, err
 		}
 
-		shouldSort := sort && !slices.IsSortedFunc(testIDs, naturalSort) && update
-		shouldDelete := hasDiffs && update
+		shouldSort := sort && !slices.IsSortedFunc(testIDs, naturalSort)
+		isDirty = isDirty || hasDiffs || (shouldSort && isCI)
 
-		isDirty = isDirty || (sort && !slices.IsSortedFunc(testIDs, naturalSort)) || hasDiffs
+		shouldDelete := update && hasDiffs
 
 		// if we don't have to "write" anything on the snap we skip
 		if !shouldDelete && !shouldSort {

--- a/snaps/clean_test.go
+++ b/snaps/clean_test.go
@@ -220,6 +220,8 @@ func TestExamineSnaps(t *testing.T) {
 		// Content of snaps is not changed
 		test.Equal(t, mockSnap1, []byte(content1))
 		test.Equal(t, mockSnap2, []byte(content2))
+
+		// And thus we are dirty since the contents do need changing
 		test.True(t, isDirty)
 	})
 
@@ -276,13 +278,15 @@ string hello world 2 2 1
 		)
 		test.NoError(t, err)
 
-		// Content of snaps is not changed
+		// Content of snaps have been updated
 		test.Equal(t, expected1, content1)
 		test.Equal(t, expected2, content2)
-		test.True(t, isDirty)
+
+		// And thus we are not dirty
+		test.False(t, isDirty)
 	})
 
-	t.Run("should sort all tests", func(t *testing.T) {
+	t.Run("should sort all tests when allowed to update", func(t *testing.T) {
 		shouldUpdate, sort := true, true
 		mockSnap1 := loadMockSnap(t, "mock-snap-sort-1")
 		mockSnap2 := loadMockSnap(t, "mock-snap-sort-2")
@@ -306,8 +310,11 @@ string hello world 2 2 1
 		content1 := test.GetFileContent(t, filepath.FromSlash(dir1+"/test1.snap"))
 		content2 := test.GetFileContent(t, filepath.FromSlash(dir2+"/test2.snap"))
 
+		// Content of snaps are now sorted
 		test.Equal(t, string(expectedMockSnap1), content1)
 		test.Equal(t, string(expectedMockSnap2), content2)
+
+		// And thus we are not dirty
 		test.False(t, isDirty)
 	})
 
@@ -347,8 +354,11 @@ string hello world 2 2 1
 			content1 := test.GetFileContent(t, filepath.FromSlash(dir1+"/test1.snap"))
 			content2 := test.GetFileContent(t, filepath.FromSlash(dir2+"/test2.snap"))
 
+			// Content of snaps is not changed
 			test.Equal(t, string(mockSnap1), content1)
 			test.Equal(t, string(mockSnap2), content2)
+
+			// And thus we are dirty, since there are obsolete snapshots that should be removed
 			test.True(t, isDirty)
 		},
 	)

--- a/snaps/clean_test.go
+++ b/snaps/clean_test.go
@@ -308,7 +308,7 @@ string hello world 2 2 1
 
 		test.Equal(t, string(expectedMockSnap1), content1)
 		test.Equal(t, string(expectedMockSnap2), content2)
-		test.True(t, isDirty)
+		test.False(t, isDirty)
 	})
 
 	t.Run(


### PR DESCRIPTION
This updates the cleaning logic to not do anything if updating is not allowed, in which case we instead mark if the snapshot needs updating (aka if it's dirty).

While the actual fix is just a few lines, I've also renamed a few variables and added some comments to make it easier (imo) to understand the logic - I'm happy to change or revert any of those if desired 🙂

Closes #134
Resolves #133