### PR TITLE
fix: don't drop /r character when scanning

### DIFF
--- a/snaps/snapshot_test.go
+++ b/snaps/snapshot_test.go
@@ -181,6 +181,13 @@ func TestGetPrevSnapshot(t *testing.T) {
 			snap:        "mysnapshot\n---moredata",
 			line:        2,
 		},
+		{
+			description: "should keep terminal \r character inside snapshot data",
+			testID:      "[my-test-crlf]",
+			fileData:    "\n[one-more-snap]\nmock-data\r\n---\n[my-test-crlf]\nline1\r\nline2\r\nline3\r\n---\n",
+			snap:        "line1\r\nline2\r\nline3\r",
+			line:        5,
+		},
 	} {
 		s := scenario
 		t.Run(s.description, func(t *testing.T) {
@@ -320,7 +327,8 @@ func TestSnapshotPath(t *testing.T) {
 }
 
 func TestUpdateSnapshot(t *testing.T) {
-	const updatedSnap = `
+	t.Run("should update snapshot", func(t *testing.T) {
+		const updatedSnap = `
 
 [Test_1/TestSimple - 1]
 int(1)
@@ -338,11 +346,27 @@ string hello world 1 3 2
 ---
 
 `
-	snapPath := test.CreateTempFile(t, mockSnap)
-	newSnapshot := "int(1250)\nstring new value"
+		snapPath := test.CreateTempFile(t, mockSnap)
+		newSnapshot := "int(1250)\nstring new value"
 
-	test.NoError(t, updateSnapshot("[Test_3/TestSimple - 1]", newSnapshot, snapPath))
-	test.Equal(t, updatedSnap, test.GetFileContent(t, snapPath))
+		test.NoError(t, updateSnapshot("[Test_3/TestSimple - 1]", newSnapshot, snapPath))
+		test.Equal(t, updatedSnap, test.GetFileContent(t, snapPath))
+	})
+
+	t.Run("should not drop terminal \r from snapshot data", func(t *testing.T) {
+		snapPath := test.CreateTempFile(
+			t,
+			"\n[mock-id]\nline1\r\nline2\r\nline3\r\n---\n[another-id]\nmoredata\n---\n",
+		)
+		newSnapshot := "updated-line1\r\nupdated-line2\r\nupdated-line3\r"
+
+		test.NoError(t, updateSnapshot("[mock-id]", newSnapshot, snapPath))
+		test.Equal(
+			t,
+			"\n[mock-id]\nupdated-line1\r\nupdated-line2\r\nupdated-line3\r\n---\n[another-id]\nmoredata\n---\n",
+			test.GetFileContent(t, snapPath),
+		)
+	})
 }
 
 func TestEscapeEndChars(t *testing.T) {

--- a/snaps/utils.go
+++ b/snaps/utils.go
@@ -2,6 +2,7 @@ package snaps
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"io"
 	"math"
@@ -113,6 +114,7 @@ func baseCaller(skip int) string {
 // snapshotScanner returns a new *bufio.Scanner with a `MaxScanTokenSize == math.MaxInt` to read from r.
 func snapshotScanner(r io.Reader) *bufio.Scanner {
 	s := bufio.NewScanner(r)
+	s.Split(scanLines)
 	s.Buffer([]byte{}, math.MaxInt)
 	return s
 }
@@ -132,6 +134,23 @@ func shouldUpdate(u *bool) bool {
 	}
 
 	return updateVAR == "true"
+}
+
+// code taken from bufio/scan.go, modified to not terminal \r from the data.
+func scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, data[0:i], nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
 }
 
 // shouldCreate determines whether snapshots should be created

--- a/snaps/utils_test.go
+++ b/snaps/utils_test.go
@@ -1,6 +1,7 @@
 package snaps
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/internal/test"
@@ -43,4 +44,59 @@ func TestBaseCaller(t *testing.T) {
 	t.Run("should return function's name", func(t *testing.T) {
 		TestBaseCallerNested(t)
 	})
+}
+
+func TestScanLines_CRLF(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "LF only",
+			input:    "line1\nline2\nline3\n",
+			expected: []string{"line1", "line2", "line3"},
+		},
+		{
+			name:     "CRLF lines",
+			input:    "line1\r\nline2\r\nline3\r\n",
+			expected: []string{"line1\r", "line2\r", "line3\r"},
+		},
+		{
+			name:     "Mixed endings",
+			input:    "line1\r\nline2\nline3\r\nline4\n",
+			expected: []string{"line1\r", "line2", "line3\r", "line4"},
+		},
+		{
+			name:     "No final newline",
+			input:    "line1\r\nline2",
+			expected: []string{"line1\r", "line2"},
+		},
+		{
+			name:     "Empty input",
+			input:    "",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := snapshotScanner(strings.NewReader(tt.input))
+			var lines []string
+			for scanner.Scan() {
+				lines = append(lines, scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				t.Fatalf("unexpected scan error: %v", err)
+			}
+			if len(lines) != len(tt.expected) {
+				t.Fatalf("expected %d lines, got %d: %v", len(tt.expected), len(lines), lines)
+			}
+			for i := range lines {
+				if lines[i] != tt.expected[i] {
+					t.Errorf("line %d: expected %q, got %q", i, tt.expected[i], lines[i])
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
tries to fix  #138 