### PR TITLE
support nested arrays in json matchers

### DIFF
--- a/examples/__snapshots__/matchJSON_test.snap
+++ b/examples/__snapshots__/matchJSON_test.snap
@@ -116,3 +116,59 @@
     "email": "mock@email.com"
 }
 ---
+
+[TestMatchers/Any_matcher/should_handle_nested_json_arrays - 1]
+{
+ "repositories": [
+  {
+   "commits": [
+    {
+     "files": [
+      {
+       "checksum": "<Any value>",
+       "path": "a.js"
+      },
+      {
+       "checksum": "<Any value>",
+       "path": "b.js"
+      }
+     ],
+     "sha": "abc123"
+    },
+    {
+     "files": [
+      {
+       "checksum": "<Any value>",
+       "path": "c.js"
+      }
+     ],
+     "sha": "def456"
+    }
+   ],
+   "name": "repo1"
+  },
+  {
+   "commits": [
+    {
+     "files": [
+      {
+       "checksum": "<Any value>",
+       "path": "d.js"
+      },
+      {
+       "checksum": "<Any value>",
+       "path": "e.js"
+      },
+      {
+       "checksum": "<Any value>",
+       "path": "f.js"
+      }
+     ],
+     "sha": "ghi789"
+    }
+   ],
+   "name": "repo2"
+  }
+ ]
+}
+---

--- a/examples/matchJSON_test.go
+++ b/examples/matchJSON_test.go
@@ -179,6 +179,43 @@ func TestMatchers(t *testing.T) {
 
 			snaps.MatchJSON(t, body, match.Any("data.createdAt"))
 		})
+
+		t.Run("should handle nested json arrays", func(t *testing.T) {
+			j := []byte(`{
+					"repositories": [
+						{
+							"name": "repo1",
+							"commits": [
+								{"sha": "abc123", "files": [{"path": "a.js", "checksum": "c1"}, {"path": "b.js", "checksum": "c2"}]},
+								{"sha": "def456", "files": [{"path": "c.js", "checksum": "c3"}]}
+							]
+						},
+						{
+							"name": "repo2",
+							"commits": [
+								{
+									"sha": "ghi789", 
+									"files": [
+										{"path": "d.js", "checksum": "c4"}, 
+										{"path": "e.js", "checksum": "c5"}, 
+										{"path": "f.js", "checksum": "c6"}
+									]
+								}
+							]
+						}
+					]
+				}`)
+
+			a := match.Any("repositories.#.commits.#.files.#.checksum").HandleNestedJSONArrays()
+
+			res, errs := a.JSON(j)
+			if len(errs) != 0 {
+				t.Errorf("unexpected errors %v", errs)
+				return
+			}
+
+			snaps.MatchJSON(t, res)
+		})
 	})
 
 	t.Run("my matcher", func(t *testing.T) {

--- a/examples/matchJSON_test.go
+++ b/examples/matchJSON_test.go
@@ -206,7 +206,7 @@ func TestMatchers(t *testing.T) {
 					]
 				}`)
 
-			a := match.Any("repositories.#.commits.#.files.#.checksum").HandleNestedJSONArrays()
+			a := match.Any("repositories.#.commits.#.files.#.checksum")
 
 			res, errs := a.JSON(j)
 			if len(errs) != 0 {

--- a/examples/matchJSON_test.go
+++ b/examples/matchJSON_test.go
@@ -206,15 +206,7 @@ func TestMatchers(t *testing.T) {
 					]
 				}`)
 
-			a := match.Any("repositories.#.commits.#.files.#.checksum")
-
-			res, errs := a.JSON(j)
-			if len(errs) != 0 {
-				t.Errorf("unexpected errors %v", errs)
-				return
-			}
-
-			snaps.MatchJSON(t, res)
+			snaps.MatchJSON(t, j, match.Any("repositories.#.commits.#.files.#.checksum"))
 		})
 	})
 

--- a/match/any.go
+++ b/match/any.go
@@ -2,7 +2,6 @@ package match
 
 import (
 	"bytes"
-	"errors"
 
 	"github.com/gkampitakis/go-snaps/match/internal/yaml"
 	"github.com/goccy/go-yaml/parser"
@@ -96,18 +95,8 @@ func (a anyMatcher) JSON(b []byte) ([]byte, []MatcherError) {
 
 	json := b
 	for _, path := range a.paths {
-		expandedPaths, err := expandArrayPaths(json, path)
-		if err != nil {
-			if errors.Is(err, errPathNotFound) && !a.errOnMissingPath {
-				continue
-			}
-
-			errs = append(errs, a.matcherError(err, path))
-			continue
-		}
-
-		for _, ep := range expandedPaths {
-			j, err := a.processPath(json, ep)
+		for _, ep := range expandArrayPaths(json, path) {
+			j, err := a.processPathJSON(json, ep)
 			if err != nil {
 				errs = append(errs, a.matcherError(err, path))
 				continue
@@ -120,7 +109,7 @@ func (a anyMatcher) JSON(b []byte) ([]byte, []MatcherError) {
 	return json, errs
 }
 
-func (a anyMatcher) processPath(json []byte, path string) ([]byte, error) {
+func (a anyMatcher) processPathJSON(json []byte, path string) ([]byte, error) {
 	r := gjson.GetBytes(json, path)
 	if !r.Exists() {
 		if a.errOnMissingPath {

--- a/match/any_test.go
+++ b/match/any_test.go
@@ -17,14 +17,15 @@ func TestAnyMatcher(t *testing.T) {
 		test.Equal(t, "Any", a.name)
 	})
 
-	t.Run("should allow overriding values", func(t *testing.T) {
+	t.Run("should allow overriding config values", func(t *testing.T) {
 		p := []string{"test.1", "test.2"}
-		a := Any(p...).ErrOnMissingPath(false).Placeholder("hello")
+		a := Any(p...).ErrOnMissingPath(false).Placeholder("hello").HandleNestedJSONArrays()
 
 		test.False(t, a.errOnMissingPath)
 		test.Equal(t, "hello", a.placeholder)
 		test.Equal(t, p, a.paths)
 		test.Equal(t, "Any", a.name)
+		test.True(t, a.handleNestedJSONArrays)
 	})
 
 	t.Run("JSON", func(t *testing.T) {
@@ -98,6 +99,97 @@ func TestAnyMatcher(t *testing.T) {
 				test.Equal(t, expected, string(res))
 			},
 		)
+
+		t.Run("HandleNestedJSONArrays", func(t *testing.T) {
+			t.Run("should return error in case of missing path", func(t *testing.T) {
+				a := Any("results.#.packages.#.vulnerabilities").HandleNestedJSONArrays()
+
+				res, errs := a.JSON(j)
+
+				test.Equal(t, j, res)
+				test.Equal(t, 1, len(errs))
+
+				err := errs[0]
+
+				test.Equal(t, "path does not exist", err.Reason.Error())
+				test.Equal(t, "Any", err.Matcher)
+				test.Equal(t, "results.#.packages.#.vulnerabilities", err.Path)
+			})
+
+			t.Run("should aggregate errors", func(t *testing.T) {
+				a := Any(
+					"results.#.packages.#.vulnerabilities",
+					"results.#.packages.#.name",
+				).HandleNestedJSONArrays()
+				res, errs := a.JSON(j)
+
+				test.Equal(t, j, res)
+				test.Equal(t, 2, len(errs))
+			})
+
+			t.Run("should replace value and return new json", func(t *testing.T) {
+				j := []byte(`{
+					"results": [
+						{
+							"packages": [
+								{"vulnerabilities": "mock-data-1", "name": "mock-name-1", "id": 12},
+								{"vulnerabilities": "mock-data-1", "name": "mock-name-1", "id": 15},
+								{"vulnerabilities": "mock-data-1", "name": "mock-name-1", "id": 17},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "mock-data-2", "name": "mock-name-2", "id": 22},
+								{"vulnerabilities": "mock-data-2", "name": "mock-name-2", "id": 25},
+								{"vulnerabilities": "mock-data-2", "name": "mock-name-2", "id": 27},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "mock-data-3", "name": "mock-name-3", "id": 32},
+								{"vulnerabilities": "mock-data-3", "name": "mock-name-3", "id": 35},
+								{"vulnerabilities": "mock-data-3", "name": "mock-name-3", "id": 37},
+							],
+						},
+					]
+				}`)
+				a := Any(
+					"results.#.packages.#.vulnerabilities",
+					"results.#.packages.#.name",
+					"missing.key",
+				).ErrOnMissingPath(false).HandleNestedJSONArrays()
+				res, errs := a.JSON(j)
+
+				expected := `{
+					"results": [
+						{
+							"packages": [
+								{"vulnerabilities": "<Any value>", "name": "<Any value>", "id": 12},
+								{"vulnerabilities": "<Any value>", "name": "<Any value>", "id": 15},
+								{"vulnerabilities": "<Any value>", "name": "<Any value>", "id": 17},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "<Any value>", "name": "<Any value>", "id": 22},
+								{"vulnerabilities": "<Any value>", "name": "<Any value>", "id": 25},
+								{"vulnerabilities": "<Any value>", "name": "<Any value>", "id": 27},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "<Any value>", "name": "<Any value>", "id": 32},
+								{"vulnerabilities": "<Any value>", "name": "<Any value>", "id": 35},
+								{"vulnerabilities": "<Any value>", "name": "<Any value>", "id": 37},
+							],
+						},
+					]
+				}`
+
+				test.Equal(t, 0, len(errs))
+				test.Equal(t, expected, string(res))
+			})
+		})
 	})
 
 	t.Run("YAML", func(t *testing.T) {

--- a/match/any_test.go
+++ b/match/any_test.go
@@ -101,21 +101,6 @@ func TestAnyMatcher(t *testing.T) {
 		)
 
 		t.Run("HandleNestedJSONArrays", func(t *testing.T) {
-			t.Run("should return error in case of missing path", func(t *testing.T) {
-				a := Any("results.#.packages.#.vulnerabilities").HandleNestedJSONArrays()
-
-				res, errs := a.JSON(j)
-
-				test.Equal(t, j, res)
-				test.Equal(t, 1, len(errs))
-
-				err := errs[0]
-
-				test.Equal(t, "path does not exist", err.Reason.Error())
-				test.Equal(t, "Any", err.Matcher)
-				test.Equal(t, "results.#.packages.#.vulnerabilities", err.Path)
-			})
-
 			t.Run("should aggregate errors", func(t *testing.T) {
 				a := Any(
 					"results.#.packages.#.vulnerabilities",

--- a/match/any_test.go
+++ b/match/any_test.go
@@ -51,16 +51,11 @@ func TestAnyMatcher(t *testing.T) {
 		})
 
 		t.Run("should aggregate errors", func(t *testing.T) {
-			a := Any(
-				"user.2",
-				"user.3",
-				"results.#.packages.#.vulnerabilities",
-				"results.#.packages.#.name",
-			)
+			a := Any("user.2", "user.3")
 			res, errs := a.JSON(j)
 
 			test.Equal(t, j, res)
-			test.Equal(t, 4, len(errs))
+			test.Equal(t, 2, len(errs))
 		})
 
 		t.Run("should replace value and return new json", func(t *testing.T) {
@@ -133,19 +128,6 @@ func TestAnyMatcher(t *testing.T) {
 						"results": ["<Any value>", "<Any value>" ],
 					},
 				]`
-
-				test.Equal(t, 0, len(errs))
-				test.Equal(t, expected, string(res))
-			})
-
-			t.Run("should replace values for single array", func(t *testing.T) {
-				j := []byte(`[1, 2, 3, 4]`)
-
-				a := Any("#.")
-
-				res, errs := a.JSON(j)
-
-				expected := `["<Any value>", "<Any value>", "<Any value>", "<Any value>"]`
 
 				test.Equal(t, 0, len(errs))
 				test.Equal(t, expected, string(res))

--- a/match/custom.go
+++ b/match/custom.go
@@ -2,6 +2,7 @@ package match
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/gkampitakis/go-snaps/match/internal/yaml"
 	"github.com/goccy/go-yaml/parser"
@@ -109,24 +110,64 @@ func (c *customMatcher) YAML(b []byte) ([]byte, []MatcherError) {
 
 // JSON is intended to be called internally on snaps.MatchJSON for applying Custom matcher
 func (c *customMatcher) JSON(b []byte) ([]byte, []MatcherError) {
-	r := gjson.GetBytes(b, c.path)
-	if !r.Exists() {
-		if c.errOnMissingPath {
-			return nil, c.matcherError(errPathNotFound)
+	var errs []MatcherError
+	json := b
+
+	for _, ep := range expandArrayPaths(json, c.path) {
+		j, err := c.processPathJSON(json, ep)
+		if err != nil {
+			errs = append(errs, c.matcherError(err)...)
+			continue
 		}
 
-		return b, nil
+		json = j
 	}
 
-	value, err := c.callback(r.Value())
-	if err != nil {
-		return nil, c.matcherError(err)
+	return json, errs
+}
+
+func (c *customMatcher) processPathJSON(json []byte, path string) ([]byte, error) {
+	r := gjson.GetBytes(json, path)
+	if !r.Exists() {
+		if c.errOnMissingPath {
+			return nil, errPathNotFound
+		}
+
+		return json, nil
 	}
 
-	b, err = sjson.SetBytesOptions(b, c.path, value, setJSONOptions)
-	if err != nil {
-		return nil, c.matcherError(err)
-	}
+	if r.IsArray() && strings.HasPrefix(path, "#.") {
+		arr := r.Array()
+		if len(arr) == 0 {
+			return json, nil
+		}
 
-	return b, nil
+		for _, item := range arr {
+			value, err := c.callback(item.Value())
+			if err != nil {
+				return nil, err
+			}
+
+			j, err := sjson.SetBytesOptions(json, path, value, setJSONOptions)
+			if err != nil {
+				return nil, err
+			}
+
+			json = j
+		}
+
+		return json, nil
+	} else {
+		value, err := c.callback(r.Value())
+		if err != nil {
+			return nil, err
+		}
+
+		j, err := sjson.SetBytesOptions(json, path, value, setJSONOptions)
+		if err != nil {
+			return nil, err
+		}
+
+		return j, nil
+	}
 }

--- a/match/custom_test.go
+++ b/match/custom_test.go
@@ -18,7 +18,7 @@ func TestCustomMatcher(t *testing.T) {
 		test.Equal(t, c.name, "Custom")
 	})
 
-	t.Run("should allow overriding values", func(t *testing.T) {
+	t.Run("should allow overriding config values", func(t *testing.T) {
 		c := Custom("path", func(val any) (any, error) {
 			return nil, nil
 		}).ErrOnMissingPath(false)
@@ -42,9 +42,8 @@ func TestCustomMatcher(t *testing.T) {
 				return nil, nil
 			})
 
-			res, errs := c.JSON(j)
+			_, errs := c.JSON(j)
 
-			test.Nil(t, res)
 			test.Equal(t, 1, len(errs))
 
 			err := errs[0]
@@ -69,9 +68,8 @@ func TestCustomMatcher(t *testing.T) {
 				return nil, errors.New("custom error")
 			})
 
-			res, errs := c.JSON(j)
+			_, errs := c.JSON(j)
 
-			test.Nil(t, res)
 			test.Equal(t, 1, len(errs))
 
 			err := errs[0]
@@ -83,6 +81,7 @@ func TestCustomMatcher(t *testing.T) {
 
 		t.Run("should apply value from custom callback to json", func(t *testing.T) {
 			c := Custom("user.email", func(val any) (any, error) {
+				test.Equal(t, "mock-email", val.(string))
 				return "replaced email", nil
 			})
 
@@ -98,6 +97,107 @@ func TestCustomMatcher(t *testing.T) {
 
 			test.Equal(t, expected, string(res))
 			test.Nil(t, errs)
+		})
+
+		t.Run("nested json arrays", func(t *testing.T) {
+			t.Run("should replace values with root level nested arrays", func(t *testing.T) {
+				j := []byte(`[
+					{
+						"results": ["mock-data-1", "mock-data-2" ],
+					},
+					{
+						"results": ["mock-data-1", "mock-data-2" ],
+					},
+					{
+						"results": ["mock-data-1", "mock-data-2" ],
+					},
+				]`)
+
+				a := Custom("#.results.#", func(val any) (any, error) {
+					return "<custom>", nil
+				})
+
+				res, errs := a.JSON(j)
+
+				expected := `[
+					{
+						"results": ["<custom>", "<custom>" ],
+					},
+					{
+						"results": ["<custom>", "<custom>" ],
+					},
+					{
+						"results": ["<custom>", "<custom>" ],
+					},
+				]`
+
+				test.Equal(t, 0, len(errs))
+				test.Equal(t, expected, string(res))
+			})
+
+			t.Run("should replace value and return new json", func(t *testing.T) {
+				j := []byte(`{
+					"results": [
+						{
+							"packages": [
+								{"vulnerabilities": "mock-data-1", "name": "mock-name-1", "id": 12},
+								{"vulnerabilities": "mock-data-1", "name": "mock-name-1", "id": 15},
+								{"vulnerabilities": "mock-data-1", "name": "mock-name-1", "id": 17},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "mock-data-2", "name": "mock-name-2", "id": 22},
+								{"vulnerabilities": "mock-data-2", "name": "mock-name-2", "id": 25},
+								{"vulnerabilities": "mock-data-2", "name": "mock-name-2", "id": 27},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "mock-data-3", "name": "mock-name-3", "id": 32},
+								{"vulnerabilities": "mock-data-3", "name": "mock-name-3", "id": 35},
+								{"vulnerabilities": "mock-data-3", "name": "mock-name-3", "id": 37},
+							],
+						},
+					]
+				}`)
+				a := Custom(
+					"results.#.packages.#.vulnerabilities",
+					func(val any) (any, error) {
+						return "<custom>", nil
+					},
+				).ErrOnMissingPath(false)
+				res, errs := a.JSON(j)
+
+				expected := `{
+					"results": [
+						{
+							"packages": [
+								{"vulnerabilities": "<custom>", "name": "mock-name-1", "id": 12},
+								{"vulnerabilities": "<custom>", "name": "mock-name-1", "id": 15},
+								{"vulnerabilities": "<custom>", "name": "mock-name-1", "id": 17},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "<custom>", "name": "mock-name-2", "id": 22},
+								{"vulnerabilities": "<custom>", "name": "mock-name-2", "id": 25},
+								{"vulnerabilities": "<custom>", "name": "mock-name-2", "id": 27},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "<custom>", "name": "mock-name-3", "id": 32},
+								{"vulnerabilities": "<custom>", "name": "mock-name-3", "id": 35},
+								{"vulnerabilities": "<custom>", "name": "mock-name-3", "id": 37},
+							],
+						},
+					]
+				}`
+
+				test.Equal(t, 0, len(errs))
+				test.Equal(t, expected, string(res))
+			})
 		})
 	})
 

--- a/match/type.go
+++ b/match/type.go
@@ -3,6 +3,7 @@ package match
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/gkampitakis/go-snaps/match/internal/yaml"
 	"github.com/goccy/go-yaml/parser"
@@ -103,19 +104,57 @@ func (t typeMatcher[ExpectedType]) JSON(b []byte) ([]byte, []MatcherError) {
 	json := b
 
 	for _, path := range t.paths {
-		r := gjson.GetBytes(json, path)
-		if !r.Exists() {
-			if t.errOnMissingPath {
-				errs = append(errs, t.matcherError(errPathNotFound, path))
+		for _, ep := range expandArrayPaths(json, path) {
+			j, err := t.processPathJSON(json, ep)
+			if err != nil {
+				errs = append(errs, t.matcherError(err, path))
+				continue
 			}
 
-			continue
+			json = j
+		}
+	}
+
+	return json, errs
+}
+
+func (t typeMatcher[ExpectedType]) processPathJSON(json []byte, path string) ([]byte, error) {
+	r := gjson.GetBytes(json, path)
+	if !r.Exists() {
+		if t.errOnMissingPath {
+			return nil, errPathNotFound
 		}
 
-		if err := typeCheck[ExpectedType](r.Value()); err != nil {
-			errs = append(errs, t.matcherError(err, path))
+		return json, nil
+	}
 
-			continue
+	if r.IsArray() && strings.HasPrefix(path, "#.") {
+		arr := r.Array()
+		if len(arr) == 0 {
+			return json, nil
+		}
+
+		for _, item := range arr {
+			if err := typeCheck[ExpectedType](item.Value()); err != nil {
+				return nil, err
+			}
+		}
+
+		j, err := sjson.SetBytesOptions(
+			json,
+			path,
+			// we don't support array of different types.
+			typePlaceholder(arr[0].Value()),
+			setJSONOptions,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return j, nil
+	} else {
+		if err := typeCheck[ExpectedType](r.Value()); err != nil {
+			return nil, err
 		}
 
 		j, err := sjson.SetBytesOptions(
@@ -125,15 +164,11 @@ func (t typeMatcher[ExpectedType]) JSON(b []byte) ([]byte, []MatcherError) {
 			setJSONOptions,
 		)
 		if err != nil {
-			errs = append(errs, t.matcherError(err, path))
-
-			continue
+			return nil, err
 		}
 
-		json = j
+		return j, nil
 	}
-
-	return json, errs
 }
 
 func typeCheck[ExpectedType any](value any) error {

--- a/match/type_test.go
+++ b/match/type_test.go
@@ -18,7 +18,7 @@ func TestTypeMatcher(t *testing.T) {
 		test.Equal(t, reflect.TypeOf("").String(), reflect.TypeOf(tm.expectedType).String())
 	})
 
-	t.Run("should allow overriding values", func(t *testing.T) {
+	t.Run("should allow overriding config values", func(t *testing.T) {
 		p := []string{"test.1", "test.2"}
 		tm := Type[string](p...)
 
@@ -86,6 +86,104 @@ func TestTypeMatcher(t *testing.T) {
 			test.Equal(t, 2, len(errs))
 			test.Equal(t, "expected type int, received string", errs[0].Reason.Error())
 			test.Equal(t, "expected type int, received float64", errs[1].Reason.Error())
+		})
+
+		t.Run("nested json arrays", func(t *testing.T) {
+			t.Run("should replace values with root level nested arrays", func(t *testing.T) {
+				j := []byte(`[
+					{
+						"results": ["mock-data-1", "mock-data-2" ],
+					},
+					{
+						"results": ["mock-data-1", "mock-data-2" ],
+					},
+					{
+						"results": ["mock-data-1", "mock-data-2" ],
+					},
+				]`)
+
+				a := Type[string]("#.results.#")
+
+				res, errs := a.JSON(j)
+
+				expected := `[
+					{
+						"results": ["<Type:string>", "<Type:string>" ],
+					},
+					{
+						"results": ["<Type:string>", "<Type:string>" ],
+					},
+					{
+						"results": ["<Type:string>", "<Type:string>" ],
+					},
+				]`
+
+				test.Equal(t, 0, len(errs))
+				test.Equal(t, expected, string(res))
+			})
+
+			t.Run("should replace value and return new json", func(t *testing.T) {
+				j := []byte(`{
+					"results": [
+						{
+							"packages": [
+								{"vulnerabilities": "mock-data-1", "name": "mock-name-1", "id": 12},
+								{"vulnerabilities": "mock-data-1", "name": "mock-name-1", "id": 15},
+								{"vulnerabilities": "mock-data-1", "name": "mock-name-1", "id": 17},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "mock-data-2", "name": "mock-name-2", "id": 22},
+								{"vulnerabilities": "mock-data-2", "name": "mock-name-2", "id": 25},
+								{"vulnerabilities": "mock-data-2", "name": "mock-name-2", "id": 27},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "mock-data-3", "name": "mock-name-3", "id": 32},
+								{"vulnerabilities": "mock-data-3", "name": "mock-name-3", "id": 35},
+								{"vulnerabilities": "mock-data-3", "name": "mock-name-3", "id": 37},
+							],
+						},
+					]
+				}`)
+				a := Type[string](
+					"results.#.packages.#.vulnerabilities",
+					"results.#.packages.#.name",
+					"missing.key",
+				).ErrOnMissingPath(false)
+				res, errs := a.JSON(j)
+
+				expected := `{
+					"results": [
+						{
+							"packages": [
+								{"vulnerabilities": "<Type:string>", "name": "<Type:string>", "id": 12},
+								{"vulnerabilities": "<Type:string>", "name": "<Type:string>", "id": 15},
+								{"vulnerabilities": "<Type:string>", "name": "<Type:string>", "id": 17},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "<Type:string>", "name": "<Type:string>", "id": 22},
+								{"vulnerabilities": "<Type:string>", "name": "<Type:string>", "id": 25},
+								{"vulnerabilities": "<Type:string>", "name": "<Type:string>", "id": 27},
+							],
+						},
+						{
+							"packages": [
+								{"vulnerabilities": "<Type:string>", "name": "<Type:string>", "id": 32},
+								{"vulnerabilities": "<Type:string>", "name": "<Type:string>", "id": 35},
+								{"vulnerabilities": "<Type:string>", "name": "<Type:string>", "id": 37},
+							],
+						},
+					]
+				}`
+
+				test.Equal(t, 0, len(errs))
+				test.Equal(t, expected, string(res))
+			})
 		})
 	})
 

--- a/match/utils.go
+++ b/match/utils.go
@@ -2,7 +2,10 @@ package match
 
 import (
 	"errors"
+	"strconv"
+	"strings"
 
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -27,4 +30,55 @@ type MatcherError struct {
 	Reason  error
 	Matcher string
 	Path    string
+}
+
+// gjsonExpandPath takes a gjson path, checks for nested access of arrays
+// and returns all possible paths to be used for setting values
+func gjsonExpandPath(data []byte, path string) ([]string, error) {
+	// if no array access, return the path as is
+	if !strings.Contains(path, "#") {
+		return []string{path}, nil
+	}
+
+	// Get the path ending with #
+	// E.g. results.#.packages.#.vulnerabilities => results.#.packages.#
+	numOfEntriesPath := path[:strings.LastIndex(path, "#")+1]
+	// This returns a potentially nested array of array lengths
+	numOfEntries := gjson.GetBytes(data, numOfEntriesPath)
+	if !numOfEntries.Exists() {
+		return nil, errPathNotFound
+	}
+
+	return constructExpandedPaths(path, numOfEntries)
+}
+
+func constructExpandedPaths(path string, structure gjson.Result) ([]string, error) {
+	paths := []string{}
+
+	if structure.IsArray() {
+		// More nesting to go
+		for i, res := range structure.Array() {
+			p, err := constructExpandedPaths(
+				// Replace the first # with actual index
+				strings.Replace(path, "#", strconv.Itoa(i), 1),
+				res,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			paths = append(paths, p...)
+		}
+	} else {
+		// Otherwise assume it is a number
+		if strings.Count(path, "#") != 1 {
+			return nil, errors.New("programmer error: there should only be 1 # left")
+		}
+		for i2 := range int(structure.Int()) {
+			newPath := strings.Replace(path, "#", strconv.Itoa(i2), 1)
+			paths = append(paths, newPath)
+		}
+	}
+
+	return paths, nil
 }

--- a/match/utils.go
+++ b/match/utils.go
@@ -32,20 +32,7 @@ type MatcherError struct {
 	Path    string
 }
 
-func expandArrayPaths(jsonInput []byte, path string) ([]string, error) {
-	if path == "#." {
-		r := gjson.ParseBytes(jsonInput)
-		if !r.IsArray() {
-			return []string{}, nil
-		}
-
-		paths := make([]string, 0, len(r.Array()))
-		for i := range r.Array() {
-			paths = append(paths, strconv.Itoa(i))
-		}
-		return paths, nil
-	}
-
+func expandArrayPaths(jsonInput []byte, path string) []string {
 	// split on the first intermediate #, if present
 	pathToArray, restOfPath, hasArrayPlaceholder := strings.Cut(path, ".#.")
 
@@ -56,16 +43,13 @@ func expandArrayPaths(jsonInput []byte, path string) ([]string, error) {
 
 	// if there are no array placeholders in the path, just return it
 	if !hasArrayPlaceholder {
-		return []string{path}, nil
+		return []string{path}
 	}
 
 	r := gjson.GetBytes(jsonInput, pathToArray)
-	if !r.Exists() {
-		return []string{}, errPathNotFound
-	}
 	// skip properties that are not arrays
 	if !r.IsArray() {
-		return []string{}, nil
+		return []string{}
 	}
 
 	// if property exists and is actually an array, build out the path to each item
@@ -78,13 +62,9 @@ func expandArrayPaths(jsonInput []byte, path string) ([]string, error) {
 		if restOfPath != "" {
 			static += "." + restOfPath
 		}
-		nestedPaths, err := expandArrayPaths(jsonInput, static)
-		if err != nil {
-			return nil, err
-		}
 
-		paths = append(paths, nestedPaths...)
+		paths = append(paths, expandArrayPaths(jsonInput, static)...)
 	}
 
-	return paths, nil
+	return paths
 }

--- a/match/utils_test.go
+++ b/match/utils_test.go
@@ -1,0 +1,541 @@
+package match
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/internal/test"
+	"github.com/tidwall/gjson"
+)
+
+func TestGjsonExpandPath(t *testing.T) {
+	t.Run("simple cases", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			data     []byte
+			path     string
+			expected []string
+			wantErr  bool
+		}{
+			{
+				name:     "simple path without array access",
+				data:     []byte(`{"user": {"name": "John"}}`),
+				path:     "user.name",
+				expected: []string{"user.name"},
+				wantErr:  false,
+			},
+			{
+				name:     "single level array access",
+				data:     []byte(`{"items": [1, 2, 3]}`),
+				path:     "items.#.value",
+				expected: []string{"items.0.value", "items.1.value", "items.2.value"},
+				wantErr:  false,
+			},
+			{
+				name:     "empty array",
+				data:     []byte(`{"items": []}`),
+				path:     "items.#.value",
+				expected: []string{},
+				wantErr:  false,
+			},
+			{
+				name:     "array with single element",
+				data:     []byte(`{"items": [42]}`),
+				path:     "items.#.value",
+				expected: []string{"items.0.value"},
+				wantErr:  false,
+			},
+			{
+				name:     "path with # at the end",
+				data:     []byte(`{"items": [1, 2, 3]}`),
+				path:     "items.#",
+				expected: []string{"items.0", "items.1", "items.2"},
+				wantErr:  false,
+			},
+			{
+				name:     "path without # returns as-is",
+				data:     []byte(`{"a": {"b": {"c": "value"}}}`),
+				path:     "a.b.c",
+				expected: []string{"a.b.c"},
+				wantErr:  false,
+			},
+			{
+				name:     "root level array",
+				data:     []byte(`[1, 2, 3]`),
+				path:     "#.value",
+				expected: []string{"0.value", "1.value", "2.value"},
+				wantErr:  false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := gjsonExpandPath(tt.data, tt.path)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("gjsonExpandPath() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				test.Equal(t, tt.expected, got)
+			})
+		}
+	})
+
+	t.Run("nested arrays", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			data     []byte
+			path     string
+			expected []string
+			wantErr  bool
+		}{
+			{
+				name: "two-level nested arrays",
+				data: []byte(`{"results": [{"packages": [1, 2]}, {"packages": [3, 4, 5]}]}`),
+				path: "results.#.packages.#.vulnerabilities",
+				expected: []string{
+					"results.0.packages.0.vulnerabilities",
+					"results.0.packages.1.vulnerabilities",
+					"results.1.packages.0.vulnerabilities",
+					"results.1.packages.1.vulnerabilities",
+					"results.1.packages.2.vulnerabilities",
+				},
+				wantErr: false,
+			},
+			{
+				name: "three levels of nesting",
+				data: []byte(`{"a": [{"b": [{"c": [1, 2]}]}]}`),
+				path: "a.#.b.#.c.#.d",
+				expected: []string{
+					"a.0.b.0.c.0.d",
+					"a.0.b.0.c.1.d",
+				},
+				wantErr: false,
+			},
+			{
+				name: "four levels of nesting",
+				data: []byte(`{"l1": [{"l2": [{"l3": [{"l4": [1, 2]}, {"l4": [3]}]}]}]}`),
+				path: "l1.#.l2.#.l3.#.l4.#.value",
+				expected: []string{
+					"l1.0.l2.0.l3.0.l4.0.value",
+					"l1.0.l2.0.l3.0.l4.1.value",
+					"l1.0.l2.0.l3.1.l4.0.value",
+				},
+				wantErr: false,
+			},
+			{
+				name: "asymmetric nested arrays",
+				data: []byte(`{"data": [{"items": [1, 2, 3]}, {"items": []}, {"items": [4]}]}`),
+				path: "data.#.items.#.value",
+				expected: []string{
+					"data.0.items.0.value",
+					"data.0.items.1.value",
+					"data.0.items.2.value",
+					"data.2.items.0.value",
+				},
+				wantErr: false,
+			},
+			{
+				name: "mixed nested arrays with different lengths at each level",
+				data: []byte(`{
+					"regions": [
+						{
+							"cities": [
+								{"districts": [1, 2, 3]},
+								{"districts": [4]}
+							]
+						},
+						{
+							"cities": [
+								{"districts": []},
+								{"districts": [5, 6]}
+							]
+						},
+						{
+							"cities": []
+						}
+					]
+				}`),
+				path: "regions.#.cities.#.districts.#.name",
+				expected: []string{
+					"regions.0.cities.0.districts.0.name",
+					"regions.0.cities.0.districts.1.name",
+					"regions.0.cities.0.districts.2.name",
+					"regions.0.cities.1.districts.0.name",
+					"regions.1.cities.1.districts.0.name",
+					"regions.1.cities.1.districts.1.name",
+				},
+				wantErr: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := gjsonExpandPath(tt.data, tt.path)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("gjsonExpandPath() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				test.Equal(t, tt.expected, got)
+			})
+		}
+	})
+
+	t.Run("complex real-world scenarios", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			data     []byte
+			path     string
+			expected []string
+			wantErr  bool
+		}{
+			{
+				name: "GitHub API response structure",
+				data: []byte(`{
+					"repositories": [
+						{
+							"name": "repo1",
+							"commits": [
+								{"sha": "abc123", "files": [{"path": "a.js", "checksum": "c1"}, {"path": "b.js", "checksum": "c2"}]},
+								{"sha": "def456", "files": [{"path": "c.js", "checksum": "c3"}]}
+							]
+						},
+						{
+							"name": "repo2",
+							"commits": [
+								{
+									"sha": "ghi789", 
+									"files": [
+										{"path": "d.js", "checksum": "c4"}, 
+										{"path": "e.js", "checksum": "c5"}, 
+										{"path": "f.js", "checksum": "c6"}
+									]
+								}
+							]
+						}
+					]
+				}`),
+				path: "repositories.#.commits.#.files.#.checksum",
+				expected: []string{
+					"repositories.0.commits.0.files.0.checksum",
+					"repositories.0.commits.0.files.1.checksum",
+					"repositories.0.commits.1.files.0.checksum",
+					"repositories.1.commits.0.files.0.checksum",
+					"repositories.1.commits.0.files.1.checksum",
+					"repositories.1.commits.0.files.2.checksum",
+				},
+				wantErr: false,
+			},
+			{
+				name: "vulnerability scanner output",
+				data: []byte(`{
+					"scan_results": [
+						{
+							"target": "app1",
+							"dependencies": [
+								{
+									"name": "lodash",
+									"vulnerabilities": [
+										{"severity": "high", "cves": ["CVE-2021-1", "CVE-2021-2"]},
+										{"severity": "medium", "cves": ["CVE-2020-1"]}
+									]
+								},
+								{
+									"name": "express",
+									"vulnerabilities": []
+								}
+							]
+						},
+						{
+							"target": "app2",
+							"dependencies": [
+								{
+									"name": "react",
+									"vulnerabilities": [
+										{"severity": "low", "cves": ["CVE-2019-1"]}
+									]
+								}
+							]
+						}
+					]
+				}`),
+				path: "scan_results.#.dependencies.#.vulnerabilities.#.id",
+				expected: []string{
+					"scan_results.0.dependencies.0.vulnerabilities.0.id",
+					"scan_results.0.dependencies.0.vulnerabilities.1.id",
+					"scan_results.1.dependencies.0.vulnerabilities.0.id",
+				},
+				wantErr: false,
+			},
+			{
+				name: "e-commerce order with nested items",
+				data: []byte(`{
+					"orders": [
+						{
+							"id": "order1",
+							"items": [
+								{
+									"product": "laptop",
+									"variants": [
+										{"sku": "LAP-001", "reviews": [{"rating": 5}, {"rating": 4}]},
+										{"sku": "LAP-002", "reviews": [{"rating": 3}]}
+									]
+								},
+								{
+									"product": "mouse",
+									"variants": [
+										{"sku": "MOU-001", "reviews": []}
+									]
+								}
+							]
+						},
+						{
+							"id": "order2",
+							"items": []
+						}
+					]
+				}`),
+				path: "orders.#.items.#.variants.#.reviews.#.verified",
+				expected: []string{
+					"orders.0.items.0.variants.0.reviews.0.verified",
+					"orders.0.items.0.variants.0.reviews.1.verified",
+					"orders.0.items.0.variants.1.reviews.0.verified",
+				},
+				wantErr: false,
+			},
+			{
+				name: "cloud infrastructure with regions and zones",
+				data: []byte(`{
+					"cloud_providers": [
+						{
+							"name": "AWS",
+							"regions": [
+								{
+									"code": "us-east-1",
+									"zones": [
+										{"name": "us-east-1a", "instances": [{"id": "i-1"}, {"id": "i-2"}]},
+										{"name": "us-east-1b", "instances": [{"id": "i-3"}]}
+									]
+								},
+								{
+									"code": "us-west-2",
+									"zones": [
+										{"name": "us-west-2a", "instances": []}
+									]
+								}
+							]
+						},
+						{
+							"name": "GCP",
+							"regions": [
+								{
+									"code": "us-central1",
+									"zones": [
+										{"name": "us-central1-a", "instances": [{"id": "gcp-1"}]}
+									]
+								}
+							]
+						}
+					]
+				}`),
+				path: "cloud_providers.#.regions.#.zones.#.instances.#.status",
+				expected: []string{
+					"cloud_providers.0.regions.0.zones.0.instances.0.status",
+					"cloud_providers.0.regions.0.zones.0.instances.1.status",
+					"cloud_providers.0.regions.0.zones.1.instances.0.status",
+					"cloud_providers.1.regions.0.zones.0.instances.0.status",
+				},
+				wantErr: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// Validate JSON is well-formed
+				var js interface{}
+				if err := json.Unmarshal(tt.data, &js); err != nil {
+					t.Fatalf("Invalid test JSON: %v", err)
+				}
+
+				got, err := gjsonExpandPath(tt.data, tt.path)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("gjsonExpandPath() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				test.Equal(t, tt.expected, got)
+			})
+		}
+	})
+
+	t.Run("edge cases and boundary conditions", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			data          []byte
+			path          string
+			expected      []string
+			expectedError error
+		}{
+			{
+				name: "array with many elements (10+)",
+				data: []byte(`{"items": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]}`),
+				path: "items.#.value",
+				expected: []string{
+					"items.0.value", "items.1.value", "items.2.value", "items.3.value",
+					"items.4.value", "items.5.value", "items.6.value", "items.7.value",
+					"items.8.value", "items.9.value", "items.10.value", "items.11.value",
+					"items.12.value", "items.13.value", "items.14.value", "items.15.value",
+				},
+				expectedError: nil,
+			},
+			{
+				name: "nested array with 100+ total paths",
+				data: func() []byte {
+					// Generate JSON with 10x10 nested structure = 100 paths
+					type Inner struct {
+						Values []int `json:"values"`
+					}
+					type Outer struct {
+						Items []Inner `json:"items"`
+					}
+					root := struct {
+						Data []Outer `json:"data"`
+					}{
+						Data: make([]Outer, 10),
+					}
+					for i := range root.Data {
+						root.Data[i].Items = make([]Inner, 10)
+						for j := range root.Data[i].Items {
+							root.Data[i].Items[j].Values = []int{1}
+						}
+					}
+					b, _ := json.Marshal(root)
+					return b
+				}(),
+				path: "data.#.items.#.values.#.id",
+				expected: func() []string {
+					paths := make([]string, 0, 100)
+					for i := range 10 {
+						for j := range 10 {
+							paths = append(paths, fmt.Sprintf("data.%d.items.%d.values.0.id", i, j))
+						}
+					}
+					return paths
+				}(),
+				expectedError: nil,
+			},
+			{
+				name:          "all empty arrays in nested structure",
+				data:          []byte(`{"a": [{"b": []}, {"b": []}]}`),
+				path:          "a.#.b.#.c",
+				expected:      []string{},
+				expectedError: nil,
+			},
+			{
+				name:          "single element at each level",
+				data:          []byte(`{"a": [{"b": [{"c": [{"d": [1]}]}]}]}`),
+				path:          "a.#.b.#.c.#.d.#.e",
+				expected:      []string{"a.0.b.0.c.0.d.0.e"},
+				expectedError: nil,
+			},
+			{
+				name: "highly unbalanced tree structure",
+				data: []byte(`{
+					"items": [
+						{"children": [{"grandchildren": [1,2,3,4,5,6,7,8,9,10]}]},
+						{"children": [{"grandchildren": [1]}]},
+						{"children": [{"grandchildren": []}]},
+						{"children": []}
+					]
+				}`),
+				path: "items.#.children.#.grandchildren.#.value",
+				expected: []string{
+					"items.0.children.0.grandchildren.0.value",
+					"items.0.children.0.grandchildren.1.value",
+					"items.0.children.0.grandchildren.2.value",
+					"items.0.children.0.grandchildren.3.value",
+					"items.0.children.0.grandchildren.4.value",
+					"items.0.children.0.grandchildren.5.value",
+					"items.0.children.0.grandchildren.6.value",
+					"items.0.children.0.grandchildren.7.value",
+					"items.0.children.0.grandchildren.8.value",
+					"items.0.children.0.grandchildren.9.value",
+					"items.1.children.0.grandchildren.0.value",
+				},
+				expectedError: nil,
+			},
+			{
+				name: "multiple # in different branches",
+				data: []byte(`{
+					"branch_a": [{"data": [1, 2]}],
+					"branch_b": [{"data": [3, 4, 5]}]
+				}`),
+				path:          "branch_a.#.data.#.value",
+				expected:      []string{"branch_a.0.data.0.value", "branch_a.0.data.1.value"},
+				expectedError: nil,
+			},
+			{
+				name:          "path with non-existent intermediate key",
+				data:          []byte(`{"items": []}`),
+				path:          "nonexistent.#.value",
+				expected:      []string{},
+				expectedError: errPathNotFound,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := gjsonExpandPath(tt.data, tt.path)
+				if tt.expectedError != nil {
+					if err == nil || err.Error() != tt.expectedError.Error() {
+						t.Errorf("expected error %v, got %v", tt.expectedError, err)
+					}
+					return
+				}
+
+				test.NoError(t, err)
+				test.Equal(t, tt.expected, got)
+			})
+		}
+	})
+}
+
+func TestConstructExpandedPaths(t *testing.T) {
+	t.Run("error cases", func(t *testing.T) {
+		t.Run("should error when multiple # remain with non-array structure", func(t *testing.T) {
+			// This simulates the programmer error case where the structure is a number
+			// but the path still has multiple # (which should never happen in practice)
+			// This tests the internal invariant check
+			data := []byte(`{"items": 5}`)
+			path := "items.#.nested.#.value"
+
+			// Get a gjson.Result that is a number
+			numOfEntries := gjson.GetBytes(data, "items")
+
+			// Try to expand a path with multiple # when structure is just a number
+			_, err := constructExpandedPaths(path, numOfEntries)
+
+			if err == nil {
+				t.Error("expected error but got nil")
+			}
+			test.Equal(t, "programmer error: there should only be 1 # left", err.Error())
+		})
+
+		t.Run("should propagate error from recursive call", func(t *testing.T) {
+			// This tests error propagation through the recursive structure
+			// We create a nested array where the inner structure will trigger an error
+			data := []byte(`{"outer": [[5]]}`)
+			path := "outer.#.#.nested.#.value"
+
+			// Get the nested array structure
+			numOfEntries := gjson.GetBytes(data, "outer.#.#")
+
+			// This should trigger the error in a nested recursive call
+			_, err := constructExpandedPaths(path, numOfEntries)
+
+			if err == nil {
+				t.Error("expected error but got nil")
+			}
+			test.Equal(t, "programmer error: there should only be 1 # left", err.Error())
+		})
+	})
+}

--- a/match/utils_test.go
+++ b/match/utils_test.go
@@ -62,15 +62,30 @@ func TestGjsonExpandPath(t *testing.T) {
 			{
 				name:     "root level array",
 				data:     []byte(`[1, 2, 3]`),
-				path:     "#.value",
-				expected: []string{"0.value", "1.value", "2.value"},
+				path:     "#.",
+				expected: []string{"0", "1", "2"},
+				wantErr:  false,
+			},
+			{
+				name: "root level array with nested arrays",
+				data: []byte(`[
+					{"results": ["data1", "data2"]},
+					{"results": ["data3", "data4", "data5"]}
+				]`),
+				path:     "#.results.#",
+				expected: []string{"#.results.0", "#.results.1"},
 				wantErr:  false,
 			},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				test.Equal(t, tt.expected, expandArrayPaths(tt.data, tt.path))
+				got, err := expandArrayPaths(tt.data, tt.path)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("gjsonExpandPath() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				test.Equal(t, tt.expected, got)
 			})
 		}
 	})
@@ -165,7 +180,12 @@ func TestGjsonExpandPath(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				test.Equal(t, tt.expected, expandArrayPaths(tt.data, tt.path))
+				got, err := expandArrayPaths(tt.data, tt.path)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("gjsonExpandPath() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				test.Equal(t, tt.expected, got)
 			})
 		}
 	})
@@ -340,7 +360,12 @@ func TestGjsonExpandPath(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				test.Equal(t, tt.expected, expandArrayPaths(tt.data, tt.path))
+				got, err := expandArrayPaths(tt.data, tt.path)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("gjsonExpandPath() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				test.Equal(t, tt.expected, got)
 			})
 		}
 	})
@@ -462,7 +487,16 @@ func TestGjsonExpandPath(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				test.Equal(t, tt.expected, expandArrayPaths(tt.data, tt.path))
+				got, err := expandArrayPaths(tt.data, tt.path)
+				if tt.expectedError != nil {
+					if err == nil || err.Error() != tt.expectedError.Error() {
+						t.Errorf("expected error %v, got %v", tt.expectedError, err)
+					}
+					return
+				}
+
+				test.NoError(t, err)
+				test.Equal(t, tt.expected, got)
 			})
 		}
 	})

--- a/match/utils_test.go
+++ b/match/utils_test.go
@@ -15,56 +15,42 @@ func TestGjsonExpandPath(t *testing.T) {
 			data     []byte
 			path     string
 			expected []string
-			wantErr  bool
 		}{
 			{
 				name:     "simple path without array access",
 				data:     []byte(`{"user": {"name": "John"}}`),
 				path:     "user.name",
 				expected: []string{"user.name"},
-				wantErr:  false,
 			},
 			{
 				name:     "single level array access",
 				data:     []byte(`{"items": [1, 2, 3]}`),
 				path:     "items.#.value",
 				expected: []string{"items.0.value", "items.1.value", "items.2.value"},
-				wantErr:  false,
 			},
 			{
 				name:     "empty array",
 				data:     []byte(`{"items": []}`),
 				path:     "items.#.value",
 				expected: []string{},
-				wantErr:  false,
 			},
 			{
 				name:     "array with single element",
 				data:     []byte(`{"items": [42]}`),
 				path:     "items.#.value",
 				expected: []string{"items.0.value"},
-				wantErr:  false,
 			},
 			{
 				name:     "path with # at the end",
 				data:     []byte(`{"items": [1, 2, 3]}`),
 				path:     "items.#",
 				expected: []string{"items.0", "items.1", "items.2"},
-				wantErr:  false,
 			},
 			{
 				name:     "path without # returns as-is",
 				data:     []byte(`{"a": {"b": {"c": "value"}}}`),
 				path:     "a.b.c",
 				expected: []string{"a.b.c"},
-				wantErr:  false,
-			},
-			{
-				name:     "root level array",
-				data:     []byte(`[1, 2, 3]`),
-				path:     "#.",
-				expected: []string{"0", "1", "2"},
-				wantErr:  false,
 			},
 			{
 				name: "root level array with nested arrays",
@@ -74,18 +60,12 @@ func TestGjsonExpandPath(t *testing.T) {
 				]`),
 				path:     "#.results.#",
 				expected: []string{"#.results.0", "#.results.1"},
-				wantErr:  false,
 			},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				got, err := expandArrayPaths(tt.data, tt.path)
-				if (err != nil) != tt.wantErr {
-					t.Errorf("gjsonExpandPath() error = %v, wantErr %v", err, tt.wantErr)
-					return
-				}
-				test.Equal(t, tt.expected, got)
+				test.Equal(t, tt.expected, expandArrayPaths(tt.data, tt.path))
 			})
 		}
 	})
@@ -96,7 +76,6 @@ func TestGjsonExpandPath(t *testing.T) {
 			data     []byte
 			path     string
 			expected []string
-			wantErr  bool
 		}{
 			{
 				name: "two-level nested arrays",
@@ -109,7 +88,6 @@ func TestGjsonExpandPath(t *testing.T) {
 					"results.1.packages.1.vulnerabilities",
 					"results.1.packages.2.vulnerabilities",
 				},
-				wantErr: false,
 			},
 			{
 				name: "three levels of nesting",
@@ -119,7 +97,6 @@ func TestGjsonExpandPath(t *testing.T) {
 					"a.0.b.0.c.0.d",
 					"a.0.b.0.c.1.d",
 				},
-				wantErr: false,
 			},
 			{
 				name: "four levels of nesting",
@@ -130,7 +107,6 @@ func TestGjsonExpandPath(t *testing.T) {
 					"l1.0.l2.0.l3.0.l4.1.value",
 					"l1.0.l2.0.l3.1.l4.0.value",
 				},
-				wantErr: false,
 			},
 			{
 				name: "asymmetric nested arrays",
@@ -142,7 +118,6 @@ func TestGjsonExpandPath(t *testing.T) {
 					"data.0.items.2.value",
 					"data.2.items.0.value",
 				},
-				wantErr: false,
 			},
 			{
 				name: "mixed nested arrays with different lengths at each level",
@@ -174,18 +149,12 @@ func TestGjsonExpandPath(t *testing.T) {
 					"regions.1.cities.1.districts.0.name",
 					"regions.1.cities.1.districts.1.name",
 				},
-				wantErr: false,
 			},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				got, err := expandArrayPaths(tt.data, tt.path)
-				if (err != nil) != tt.wantErr {
-					t.Errorf("gjsonExpandPath() error = %v, wantErr %v", err, tt.wantErr)
-					return
-				}
-				test.Equal(t, tt.expected, got)
+				test.Equal(t, tt.expected, expandArrayPaths(tt.data, tt.path))
 			})
 		}
 	})
@@ -196,7 +165,6 @@ func TestGjsonExpandPath(t *testing.T) {
 			data     []byte
 			path     string
 			expected []string
-			wantErr  bool
 		}{
 			{
 				name: "GitHub API response structure",
@@ -233,7 +201,6 @@ func TestGjsonExpandPath(t *testing.T) {
 					"repositories.1.commits.0.files.1.checksum",
 					"repositories.1.commits.0.files.2.checksum",
 				},
-				wantErr: false,
 			},
 			{
 				name: "vulnerability scanner output",
@@ -274,7 +241,6 @@ func TestGjsonExpandPath(t *testing.T) {
 					"scan_results.0.dependencies.0.vulnerabilities.1.id",
 					"scan_results.1.dependencies.0.vulnerabilities.0.id",
 				},
-				wantErr: false,
 			},
 			{
 				name: "e-commerce order with nested items",
@@ -310,7 +276,6 @@ func TestGjsonExpandPath(t *testing.T) {
 					"orders.0.items.0.variants.0.reviews.1.verified",
 					"orders.0.items.0.variants.1.reviews.0.verified",
 				},
-				wantErr: false,
 			},
 			{
 				name: "cloud infrastructure with regions and zones",
@@ -354,29 +319,22 @@ func TestGjsonExpandPath(t *testing.T) {
 					"cloud_providers.0.regions.0.zones.1.instances.0.status",
 					"cloud_providers.1.regions.0.zones.0.instances.0.status",
 				},
-				wantErr: false,
 			},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				got, err := expandArrayPaths(tt.data, tt.path)
-				if (err != nil) != tt.wantErr {
-					t.Errorf("gjsonExpandPath() error = %v, wantErr %v", err, tt.wantErr)
-					return
-				}
-				test.Equal(t, tt.expected, got)
+				test.Equal(t, tt.expected, expandArrayPaths(tt.data, tt.path))
 			})
 		}
 	})
 
 	t.Run("edge cases and boundary conditions", func(t *testing.T) {
 		tests := []struct {
-			name          string
-			data          []byte
-			path          string
-			expected      []string
-			expectedError error
+			name     string
+			data     []byte
+			path     string
+			expected []string
 		}{
 			{
 				name: "array with many elements (10+)",
@@ -388,7 +346,6 @@ func TestGjsonExpandPath(t *testing.T) {
 					"items.8.value", "items.9.value", "items.10.value", "items.11.value",
 					"items.12.value", "items.13.value", "items.14.value", "items.15.value",
 				},
-				expectedError: nil,
 			},
 			{
 				name: "nested array with 100+ total paths",
@@ -424,21 +381,18 @@ func TestGjsonExpandPath(t *testing.T) {
 					}
 					return paths
 				}(),
-				expectedError: nil,
 			},
 			{
-				name:          "all empty arrays in nested structure",
-				data:          []byte(`{"a": [{"b": []}, {"b": []}]}`),
-				path:          "a.#.b.#.c",
-				expected:      []string{},
-				expectedError: nil,
+				name:     "all empty arrays in nested structure",
+				data:     []byte(`{"a": [{"b": []}, {"b": []}]}`),
+				path:     "a.#.b.#.c",
+				expected: []string{},
 			},
 			{
-				name:          "single element at each level",
-				data:          []byte(`{"a": [{"b": [{"c": [{"d": [1]}]}]}]}`),
-				path:          "a.#.b.#.c.#.d.#.e",
-				expected:      []string{"a.0.b.0.c.0.d.0.e"},
-				expectedError: nil,
+				name:     "single element at each level",
+				data:     []byte(`{"a": [{"b": [{"c": [{"d": [1]}]}]}]}`),
+				path:     "a.#.b.#.c.#.d.#.e",
+				expected: []string{"a.0.b.0.c.0.d.0.e"},
 			},
 			{
 				name: "highly unbalanced tree structure",
@@ -464,7 +418,6 @@ func TestGjsonExpandPath(t *testing.T) {
 					"items.0.children.0.grandchildren.9.value",
 					"items.1.children.0.grandchildren.0.value",
 				},
-				expectedError: nil,
 			},
 			{
 				name: "multiple # in different branches",
@@ -472,31 +425,20 @@ func TestGjsonExpandPath(t *testing.T) {
 					"branch_a": [{"data": [1, 2]}],
 					"branch_b": [{"data": [3, 4, 5]}]
 				}`),
-				path:          "branch_a.#.data.#.value",
-				expected:      []string{"branch_a.0.data.0.value", "branch_a.0.data.1.value"},
-				expectedError: nil,
+				path:     "branch_a.#.data.#.value",
+				expected: []string{"branch_a.0.data.0.value", "branch_a.0.data.1.value"},
 			},
 			{
-				name:          "path with non-existent intermediate key",
-				data:          []byte(`{"items": []}`),
-				path:          "nonexistent.#.value",
-				expected:      []string{},
-				expectedError: errPathNotFound,
+				name:     "path with non-existent intermediate key",
+				data:     []byte(`{"items": []}`),
+				path:     "nonexistent.#.value",
+				expected: []string{},
 			},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				got, err := expandArrayPaths(tt.data, tt.path)
-				if tt.expectedError != nil {
-					if err == nil || err.Error() != tt.expectedError.Error() {
-						t.Errorf("expected error %v, got %v", tt.expectedError, err)
-					}
-					return
-				}
-
-				test.NoError(t, err)
-				test.Equal(t, tt.expected, got)
+				test.Equal(t, tt.expected, expandArrayPaths(tt.data, tt.path))
 			})
 		}
 	})


### PR DESCRIPTION
Using @G-Rath's provided code experimenting how we could handle on go-snaps side, supporting nested json arrays on matchers. 

Matchers: 
- [x] Any
- [x] Custom
- [x] Type


Closes #84 
