### PR TITLE
Fix Skipf test format for Go vet

### DIFF
--- a/snaps/skip_test.go
+++ b/snaps/skip_test.go
@@ -37,7 +37,7 @@ func TestSkip(t *testing.T) {
 
 		mockT := test.NewMockTestingT(t)
 		mockT.MockSkipf = func(format string, args ...any) {
-			test.Equal(t, "mock", format)
+			test.Equal(t, "mock %d %d %d %d %d", format)
 			test.Equal(t, []any{1, 2, 3, 4, 5}, args)
 		}
 		mockT.MockLog = func(args ...any) {
@@ -45,7 +45,7 @@ func TestSkip(t *testing.T) {
 		}
 		mockT.MockSkipf = func(string, ...any) {}
 
-		Skipf(mockT, "mock", 1, 2, 3, 4, 5)
+		Skipf(mockT, "mock %d %d %d %d %d", 1, 2, 3, 4, 5)
 
 		test.Equal(t, []string{"mock-name"}, skippedTests.values)
 	})


### PR DESCRIPTION
Summary:
- Keep the `Skipf` mock expectation as a format string plus arguments.
- This avoids a non-constant format issue under current Go vet while preserving the test intent.

Testing:
- `go test ./snaps -run TestSkip`

Note:
- Full `go test ./...` is currently blocked in this local non-interactive environment by existing color snapshot expectations unrelated to this change.